### PR TITLE
Add native database credentials configuration

### DIFF
--- a/rust-admin/Cargo.lock
+++ b/rust-admin/Cargo.lock
@@ -2105,6 +2105,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "url",
  "uuid",
  "validator",
 ]

--- a/rust-admin/Cargo.toml
+++ b/rust-admin/Cargo.toml
@@ -31,3 +31,4 @@ strum = { version = "0.26", features = ["derive"] }
 strum_macros = "0.26"
 anyhow = "1"
 askama = "0.12"
+url = "2"

--- a/rust-admin/README.md
+++ b/rust-admin/README.md
@@ -21,10 +21,32 @@
 
 1. **配置数据库连接**：
 
-   可以修改 `config/default.toml` 中的 `database.url`，或在启动时通过环境变量覆盖：
+   可以修改 `config/default.toml` 中的 `database.*` 字段，或在启动时通过环境变量覆盖。例如：
+
+   ```toml
+   [database]
+   url = "jdbc:mysql://127.0.0.1:3306/xxl_job?useUnicode=true&characterEncoding=UTF-8"
+   username = "root"
+   password = "root_pwd"
+   driver-class-name = "com.mysql.cj.jdbc.Driver"
+   ```
+
+   也可以使用环境变量：
 
    ```bash
-   export RUST_ADMIN__DATABASE__URL="mysql://user:pass@localhost:3306/xxl_job"
+   export RUST_ADMIN__DATABASE__URL="jdbc:mysql://127.0.0.1:3306/xxl_job"
+   export RUST_ADMIN__DATABASE__USERNAME="root"
+   export RUST_ADMIN__DATABASE__PASSWORD="root_pwd"
+   export RUST_ADMIN__DATABASE__DRIVER_CLASS_NAME="com.mysql.cj.jdbc.Driver"
+   ```
+
+   同时保持兼容原 Spring Boot 的 `spring.datasource.*` 配置方式，例如：
+
+   ```bash
+   export SPRING_DATASOURCE_URL="jdbc:mysql://127.0.0.1:3306/xxl_job?useUnicode=true&characterEncoding=UTF-8"
+   export SPRING_DATASOURCE_USERNAME="root"
+   export SPRING_DATASOURCE_PASSWORD="root_pwd"
+   export SPRING_DATASOURCE_DRIVER_CLASS_NAME="com.mysql.cj.jdbc.Driver"
    ```
 
 2. **运行服务**：

--- a/rust-admin/src/config.rs
+++ b/rust-admin/src/config.rs
@@ -1,12 +1,16 @@
 use std::net::SocketAddr;
 
-use anyhow::Context;
+use anyhow::{anyhow, Context};
 use serde::Deserialize;
+use url::Url;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Settings {
     pub server: ServerSettings,
+    #[serde(default)]
     pub database: DatabaseSettings,
+    #[serde(default)]
+    pub spring: SpringSettings,
     pub security: SecuritySettings,
 }
 
@@ -30,6 +34,65 @@ impl Settings {
             .try_deserialize()
             .context("解析配置失败")
     }
+
+    pub fn database_url(&self) -> anyhow::Result<String> {
+        if let Some(url) = self
+            .database
+            .url
+            .as_deref()
+            .filter(|url| !url.trim().is_empty())
+        {
+            if let Some(driver) = self
+                .database
+                .driver_class_name
+                .as_deref()
+                .filter(|driver| !driver.trim().is_empty())
+            {
+                if !driver.to_ascii_lowercase().contains("mysql") {
+                    return Err(anyhow!(
+                        "当前仅支持 MySQL 数据源，检测到 driver-class-name = `{driver}`"
+                    ));
+                }
+            }
+
+            return build_mysql_url(
+                url,
+                self.database.username.as_deref(),
+                self.database.password.as_deref(),
+            );
+        }
+
+        let mut datasource = self.spring.datasource.clone();
+        datasource.apply_env_overrides();
+
+        if let Some(url) = datasource
+            .url
+            .as_deref()
+            .filter(|url| !url.trim().is_empty())
+        {
+            if let Some(driver) = datasource
+                .driver_class_name
+                .as_deref()
+                .filter(|driver| !driver.trim().is_empty())
+            {
+                if !driver.to_ascii_lowercase().contains("mysql") {
+                    return Err(anyhow!(
+                        "当前仅支持 MySQL 数据源，检测到 driver-class-name = `{driver}`"
+                    ));
+                }
+            }
+
+            return build_mysql_url(
+                url,
+                datasource.username.as_deref(),
+                datasource.password.as_deref(),
+            );
+        }
+
+        Err(anyhow!(
+            "未检测到数据库连接配置，请在 config/default.toml 或环境变量中设置 `database.*` 或 `spring.datasource.*`"
+        ))
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -45,12 +108,83 @@ impl ServerSettings {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Default)]
 pub struct DatabaseSettings {
-    pub url: String,
+    pub url: Option<String>,
+    pub username: Option<String>,
+    pub password: Option<String>,
+    #[serde(rename = "driver-class-name")]
+    pub driver_class_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct SecuritySettings {
     pub token_ttl_minutes: i64,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct SpringSettings {
+    #[serde(default)]
+    pub datasource: SpringDatasourceSettings,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct SpringDatasourceSettings {
+    pub url: Option<String>,
+    pub username: Option<String>,
+    pub password: Option<String>,
+    #[serde(rename = "driver-class-name")]
+    pub driver_class_name: Option<String>,
+}
+
+impl SpringDatasourceSettings {
+    fn apply_env_overrides(&mut self) {
+        if let Ok(url) = std::env::var("SPRING_DATASOURCE_URL") {
+            if !url.trim().is_empty() {
+                self.url = Some(url);
+            }
+        }
+
+        if let Ok(username) = std::env::var("SPRING_DATASOURCE_USERNAME") {
+            if !username.trim().is_empty() {
+                self.username = Some(username);
+            }
+        }
+
+        if let Ok(password) = std::env::var("SPRING_DATASOURCE_PASSWORD") {
+            if !password.trim().is_empty() {
+                self.password = Some(password);
+            }
+        }
+
+        if let Ok(driver) = std::env::var("SPRING_DATASOURCE_DRIVER_CLASS_NAME") {
+            if !driver.trim().is_empty() {
+                self.driver_class_name = Some(driver);
+            }
+        }
+    }
+}
+
+fn build_mysql_url(
+    raw_url: &str,
+    username: Option<&str>,
+    password: Option<&str>,
+) -> anyhow::Result<String> {
+    let trimmed = raw_url.trim();
+    let without_jdbc = trimmed.strip_prefix("jdbc:").unwrap_or(trimmed);
+
+    let mut url =
+        Url::parse(without_jdbc).with_context(|| format!("解析数据库连接 URL 失败: {raw_url}"))?;
+
+    if let Some(user) = username {
+        url.set_username(user)
+            .map_err(|_| anyhow!("设置数据库用户名失败"))?;
+    }
+
+    if let Some(pass) = password {
+        url.set_password(Some(pass))
+            .map_err(|_| anyhow!("设置数据库密码失败"))?;
+    }
+
+    Ok(url.to_string())
 }

--- a/rust-admin/src/main.rs
+++ b/rust-admin/src/main.rs
@@ -24,7 +24,8 @@ async fn main() -> anyhow::Result<()> {
 
     let settings = Settings::load()?;
     let addr: SocketAddr = settings.server.socket_addr()?;
-    let db = Database::connect(&settings.database.url).await?;
+    let database_url = settings.database_url()?;
+    let db = Database::connect(&database_url).await?;
 
     let state = AppState::new(db, settings);
     let app = routes::create_router(state);


### PR DESCRIPTION
## Summary
- allow the Rust admin service to read MySQL credentials from the native `database.*` configuration keys
- continue validating the configured driver while composing the final connection string
- document the new configuration options alongside the existing Spring compatibility layer

## Testing
- cargo check


------
https://chatgpt.com/codex/tasks/task_e_68e37161b4348321a25d62af7e325392