### PR TITLE
feat: split admin console into dedicated management pages

### DIFF
--- a/rust-admin/src/routes/admin.rs
+++ b/rust-admin/src/routes/admin.rs
@@ -3,16 +3,25 @@ use axum::{response::Html, routing::get, Router};
 
 use crate::error::{AppError, AppResult};
 use crate::state::AppState;
-use crate::templates::{DashboardTemplate, LoginTemplate};
+use crate::templates::{
+    DashboardTemplate, JobGroupsTemplate, JobInfoTemplate, JobLogsTemplate, LoginTemplate,
+};
 
 const APP_NAME: &str = "XXL-JOB 管理台";
 const SUMMARY_ENDPOINT: &str = "/api/dashboard/summary";
 const CHART_ENDPOINT: &str = "/api/dashboard/chart";
+const JOB_GROUPS_ENDPOINT: &str = "/api/job-groups";
+const JOB_INFO_ENDPOINT: &str = "/api/job-info";
+const JOB_INFO_NEXT_TRIGGER_ENDPOINT: &str = "/api/job-info/next-trigger-time";
+const JOB_LOGS_ENDPOINT: &str = "/api/job-logs";
 
 pub fn router() -> Router<AppState> {
     Router::new()
         .route("/", get(login_page))
         .route("/dashboard", get(dashboard_page))
+        .route("/jobs", get(job_info_page))
+        .route("/groups", get(job_groups_page))
+        .route("/logs", get(job_logs_page))
 }
 
 async fn login_page() -> AppResult<Html<String>> {
@@ -25,8 +34,36 @@ async fn login_page() -> AppResult<Html<String>> {
 async fn dashboard_page() -> AppResult<Html<String>> {
     render_template(DashboardTemplate {
         app_name: APP_NAME,
+        active_nav: "dashboard",
         summary_endpoint: SUMMARY_ENDPOINT,
         chart_endpoint: CHART_ENDPOINT,
+    })
+}
+
+async fn job_info_page() -> AppResult<Html<String>> {
+    render_template(JobInfoTemplate {
+        app_name: APP_NAME,
+        active_nav: "jobs",
+        job_groups_endpoint: JOB_GROUPS_ENDPOINT,
+        job_info_endpoint: JOB_INFO_ENDPOINT,
+        job_info_next_trigger_endpoint: JOB_INFO_NEXT_TRIGGER_ENDPOINT,
+    })
+}
+
+async fn job_groups_page() -> AppResult<Html<String>> {
+    render_template(JobGroupsTemplate {
+        app_name: APP_NAME,
+        active_nav: "groups",
+        job_groups_endpoint: JOB_GROUPS_ENDPOINT,
+    })
+}
+
+async fn job_logs_page() -> AppResult<Html<String>> {
+    render_template(JobLogsTemplate {
+        app_name: APP_NAME,
+        active_nav: "logs",
+        job_groups_endpoint: JOB_GROUPS_ENDPOINT,
+        job_logs_endpoint: JOB_LOGS_ENDPOINT,
     })
 }
 

--- a/rust-admin/src/templates/mod.rs
+++ b/rust-admin/src/templates/mod.rs
@@ -11,6 +11,34 @@ pub struct LoginTemplate<'a> {
 #[template(path = "dashboard.html")]
 pub struct DashboardTemplate<'a> {
     pub app_name: &'a str,
+    pub active_nav: &'a str,
     pub summary_endpoint: &'a str,
     pub chart_endpoint: &'a str,
+}
+
+#[derive(Template)]
+#[template(path = "job-groups.html")]
+pub struct JobGroupsTemplate<'a> {
+    pub app_name: &'a str,
+    pub active_nav: &'a str,
+    pub job_groups_endpoint: &'a str,
+}
+
+#[derive(Template)]
+#[template(path = "job-info.html")]
+pub struct JobInfoTemplate<'a> {
+    pub app_name: &'a str,
+    pub active_nav: &'a str,
+    pub job_groups_endpoint: &'a str,
+    pub job_info_endpoint: &'a str,
+    pub job_info_next_trigger_endpoint: &'a str,
+}
+
+#[derive(Template)]
+#[template(path = "job-logs.html")]
+pub struct JobLogsTemplate<'a> {
+    pub app_name: &'a str,
+    pub active_nav: &'a str,
+    pub job_groups_endpoint: &'a str,
+    pub job_logs_endpoint: &'a str,
 }

--- a/rust-admin/templates/dashboard.html
+++ b/rust-admin/templates/dashboard.html
@@ -1,14 +1,88 @@
 {% extends "layout.html" %}
 
+{% block sidebar %}
+<aside class="sidebar card">
+    <div class="sidebar-header">
+        <div class="sidebar-title">{{ app_name }}</div>
+        <div class="sidebar-subtitle muted">分布式任务调度中心</div>
+    </div>
+    <nav class="sidebar-nav">
+        <a class="nav-link{% if active_nav == "dashboard" %} is-active{% endif %}" href="/admin/dashboard">仪表盘</a>
+        <a class="nav-link" href="/admin/jobs">任务管理</a>
+        <a class="nav-link" href="/admin/groups">执行器管理</a>
+        <a class="nav-link" href="/admin/logs">任务日志</a>
+    </nav>
+</aside>
+{% endblock %}
+
 {% block head %}
 <style>
-    body {
-        align-items: stretch;
+    :root {
+        --border-color: rgba(148, 163, 184, 0.18);
+        --muted: rgba(226, 232, 240, 0.75);
+        --accent: #38bdf8;
+        --warning: #facc15;
+        --success: #22c55e;
+        --danger: #f87171;
     }
 
-    .dashboard {
-        max-width: 1200px;
-        margin: 0 auto;
+    .sidebar {
+        width: 240px;
+        padding: 26px 22px;
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+    }
+
+    .sidebar-header {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+    }
+
+    .sidebar-title {
+        font-size: 18px;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+    }
+
+    .sidebar-subtitle {
+        font-size: 13px;
+    }
+
+    .sidebar-nav {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+    }
+
+    .nav-link {
+        display: block;
+        width: 100%;
+        padding: 12px 14px;
+        border-radius: 12px;
+        border: 1px solid transparent;
+        background: rgba(148, 163, 184, 0.08);
+        color: inherit;
+        text-decoration: none;
+        font-weight: 600;
+        transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+    }
+
+    .nav-link:hover {
+        background: rgba(56, 189, 248, 0.18);
+        border-color: rgba(56, 189, 248, 0.45);
+        transform: translateX(2px);
+    }
+
+    .nav-link.is-active {
+        background: linear-gradient(135deg, rgba(14, 165, 233, 0.22), rgba(37, 99, 235, 0.28));
+        border-color: rgba(59, 130, 246, 0.55);
+        box-shadow: 0 12px 24px rgba(37, 99, 235, 0.25);
+    }
+
+    .dashboard-view {
         display: flex;
         flex-direction: column;
         gap: 24px;
@@ -19,9 +93,9 @@
         align-items: center;
         justify-content: space-between;
         padding: 24px 28px;
-        border-bottom: 1px solid rgba(148, 163, 184, 0.15);
-        background: rgba(15, 23, 42, 0.8);
         border-radius: 18px;
+        border: 1px solid var(--border-color);
+        background: rgba(15, 23, 42, 0.8);
         box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.12);
     }
 
@@ -65,14 +139,10 @@
         transform: rotate(45deg);
     }
 
-    .summary-card span {
-        display: block;
-    }
-
     .summary-label {
         font-size: 14px;
         font-weight: 600;
-        color: rgba(226, 232, 240, 0.78);
+        color: var(--muted);
     }
 
     .summary-value {
@@ -87,13 +157,16 @@
         border: 1px solid rgba(148, 163, 184, 0.2);
         background: rgba(15, 23, 42, 0.82);
         padding: 24px 28px;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
     }
 
     .chart-header {
         display: flex;
         justify-content: space-between;
         align-items: center;
-        margin-bottom: 16px;
+        gap: 12px;
     }
 
     .chart-header h2 {
@@ -110,15 +183,15 @@
         font-size: 13px;
     }
 
-    .chart-container {
-        position: relative;
-        width: 100%;
-        overflow: hidden;
+    .chart-content {
+        display: grid;
+        gap: 16px;
+        grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
     }
 
     canvas {
         width: 100%;
-        height: 240px;
+        height: 260px;
         border-radius: 12px;
         background: rgba(15, 23, 42, 0.65);
     }
@@ -126,31 +199,15 @@
     table {
         width: 100%;
         border-collapse: collapse;
-        margin-top: 24px;
-    }
-
-    thead {
         font-size: 13px;
-        color: rgba(226, 232, 240, 0.6);
     }
 
-    th, td {
+    th,
+    td {
         text-align: left;
-        padding: 10px 0;
-        border-bottom: 1px solid rgba(148, 163, 184, 0.14);
+        padding: 8px 0;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.18);
     }
-
-    .status-dot {
-        display: inline-flex;
-        width: 10px;
-        height: 10px;
-        border-radius: 999px;
-        margin-right: 6px;
-    }
-
-    .running { background: #facc15; }
-    .success { background: #22c55e; }
-    .failed { background: #f87171; }
 
     .toast {
         position: fixed;
@@ -158,12 +215,18 @@
         right: 24px;
         padding: 12px 16px;
         border-radius: 12px;
-        background: rgba(239, 68, 68, 0.85);
+        background: rgba(56, 189, 248, 0.85);
         color: white;
-        box-shadow: 0 10px 30px rgba(239, 68, 68, 0.35);
+        box-shadow: 0 10px 30px rgba(56, 189, 248, 0.35);
         opacity: 0;
         pointer-events: none;
         transition: opacity 0.3s ease;
+        z-index: 1200;
+    }
+
+    .toast.error {
+        background: rgba(239, 68, 68, 0.85);
+        box-shadow: 0 10px 30px rgba(239, 68, 68, 0.35);
     }
 
     .toast.show {
@@ -171,77 +234,93 @@
         pointer-events: auto;
     }
 
-    @media (max-width: 768px) {
-        .top-bar {
+    @media (max-width: 1024px) {
+        .page-layout {
             flex-direction: column;
-            gap: 16px;
-            align-items: flex-start;
+        }
+
+        .sidebar {
+            width: 100%;
+            flex-direction: column;
+            gap: 18px;
+        }
+
+        .sidebar-nav {
+            flex-direction: row;
+            flex-wrap: wrap;
+        }
+
+        .nav-link {
+            flex: 1 1 160px;
+        }
+
+        .chart-content {
+            grid-template-columns: 1fr;
         }
     }
 </style>
 {% endblock %}
 
 {% block content %}
-<div class="dashboard">
+<div class="dashboard-view">
     <div class="top-bar card">
-        <h1>{{ app_name }}</h1>
+        <div>
+            <h1>运行概览</h1>
+            <div class="muted">掌握集群健康情况与调度趋势</div>
+        </div>
         <div class="user-info">
-            <span>当前账号：</span>
-            <span data-username>--</span>
-            <button id="logout-btn" type="button">退出登录</button>
+            <span id="welcome-user">--</span>
+            <button id="logout" type="button">退出登录</button>
         </div>
     </div>
-    <div class="summary-grid">
-        <div class="summary-card card">
-            <span class="summary-label">执行器数量</span>
-            <span class="summary-value" data-summary="group_count">--</span>
+
+    <section class="card">
+        <div class="summary-grid" id="summary-grid">
+            <div class="summary-card">
+                <span class="summary-label">执行器数量</span>
+                <span class="summary-value" data-summary="executorCount">--</span>
+            </div>
+            <div class="summary-card">
+                <span class="summary-label">任务数量</span>
+                <span class="summary-value" data-summary="jobCount">--</span>
+            </div>
+            <div class="summary-card">
+                <span class="summary-label">触发次数</span>
+                <span class="summary-value" data-summary="triggerCount">--</span>
+            </div>
+            <div class="summary-card">
+                <span class="summary-label">成功调度</span>
+                <span class="summary-value" data-summary="successCount">--</span>
+            </div>
         </div>
-        <div class="summary-card card">
-            <span class="summary-label">任务数量</span>
-            <span class="summary-value" data-summary="job_count">--</span>
-        </div>
-        <div class="summary-card card">
-            <span class="summary-label">日志条目</span>
-            <span class="summary-value" data-summary="log_total_count">--</span>
-        </div>
-        <div class="summary-card card">
-            <span class="summary-label">运行中</span>
-            <span class="summary-value" data-summary="log_running_count">--</span>
-        </div>
-        <div class="summary-card card">
-            <span class="summary-label">成功次数</span>
-            <span class="summary-value" data-summary="log_success_count">--</span>
-        </div>
-        <div class="summary-card card">
-            <span class="summary-label">失败次数</span>
-            <span class="summary-value" data-summary="log_fail_count">--</span>
-        </div>
-    </div>
-    <div class="chart-card card">
+    </section>
+
+    <section class="chart-card">
         <div class="chart-header">
-            <h2>近 7 天调度趋势</h2>
-            <button id="refresh-btn" type="button">刷新数据</button>
+            <h2>最近运行趋势</h2>
+            <button id="refresh-chart" type="button">刷新</button>
         </div>
-        <div class="chart-container">
-            <canvas id="chart" width="960" height="280"></canvas>
+        <div class="chart-content">
+            <canvas id="chart" width="720" height="320"></canvas>
+            <table>
+                <thead>
+                    <tr>
+                        <th>日期</th>
+                        <th>运行中</th>
+                        <th>成功</th>
+                        <th>失败</th>
+                    </tr>
+                </thead>
+                <tbody id="chart-table">
+                    <tr>
+                        <td colspan="4" class="muted">加载中...</td>
+                    </tr>
+                </tbody>
+            </table>
         </div>
-        <table>
-            <thead>
-            <tr>
-                <th>日期</th>
-                <th><span class="status-dot running"></span>运行</th>
-                <th><span class="status-dot success"></span>成功</th>
-                <th><span class="status-dot failed"></span>失败</th>
-            </tr>
-            </thead>
-            <tbody id="chart-table">
-            <tr>
-                <td colspan="4" class="muted">加载中...</td>
-            </tr>
-            </tbody>
-        </table>
-    </div>
+    </section>
 </div>
+
 <div class="toast" id="toast"></div>
 {% endblock %}
 
@@ -254,28 +333,28 @@
 
     const token = localStorage.getItem(TOKEN_KEY);
     if (!token) {
-        window.location.replace("/admin");
+        window.location.replace("/admin/");
     }
 
-    const usernameEl = document.querySelector('[data-username]');
-    usernameEl.textContent = localStorage.getItem(USERNAME_KEY) || "未登录";
+    const welcomeUser = document.getElementById("welcome-user");
+    const refreshChartBtn = document.getElementById("refresh-chart");
+    const chartTable = document.getElementById("chart-table");
+    const logoutBtn = document.getElementById("logout");
+    const toast = document.getElementById("toast");
 
-    document.getElementById('logout-btn').addEventListener('click', () => {
+    welcomeUser.textContent = localStorage.getItem(USERNAME_KEY) || "未登录";
+
+    logoutBtn.addEventListener("click", () => {
         localStorage.removeItem(TOKEN_KEY);
         localStorage.removeItem(USERNAME_KEY);
-        window.location.href = '/admin';
+        window.location.replace("/admin/");
     });
 
-    const summaryFields = document.querySelectorAll('[data-summary]');
-    const chartTable = document.getElementById('chart-table');
-    const refreshBtn = document.getElementById('refresh-btn');
-    const toast = document.getElementById('toast');
+    refreshChartBtn.addEventListener("click", loadData);
 
-    refreshBtn.addEventListener('click', () => {
-        loadDashboard();
-    });
+    loadData();
 
-    async function loadDashboard() {
+    async function loadData() {
         try {
             const [summary, chart] = await Promise.all([
                 fetchJson(SUMMARY_ENDPOINT),
@@ -283,37 +362,38 @@
             ]);
             renderSummary(summary);
             renderChart(chart);
-            renderTable(chart);
+            renderChartTable(chart);
         } catch (error) {
-            showToast(error.message || '加载数据失败');
+            showToast(error.message || "加载失败", true);
         }
     }
 
-    async function fetchJson(url) {
+    async function fetchJson(url, options = {}) {
         const response = await fetch(url, {
+            ...options,
             headers: {
+                "Content-Type": "application/json",
                 Authorization: `Bearer ${token}`,
+                ...(options.headers || {}),
             },
         });
         if (!response.ok) {
-            if (response.status === 401) {
-                localStorage.removeItem(TOKEN_KEY);
-                localStorage.removeItem(USERNAME_KEY);
-                window.location.href = '/admin';
-                return Promise.reject(new Error('未认证'));
-            }
-            const error = await response.json().catch(() => ({ message: '请求失败' }));
-            throw new Error(error.message || '请求失败');
+            const message = await response.json().catch(() => ({}));
+            throw new Error(message.message || response.statusText);
         }
         return response.json();
     }
 
     function renderSummary(summary) {
-        summaryFields.forEach((field) => {
-            const key = field.getAttribute('data-summary');
-            const value = summary[key];
-            field.textContent = typeof value === 'number' ? value.toLocaleString() : '--';
-        });
+        const summaryMap = {
+            executorCount: summary.executorCount ?? 0,
+            jobCount: summary.jobCount ?? 0,
+            triggerCount: summary.triggerCount ?? 0,
+            successCount: summary.successCount ?? 0,
+        };
+        document
+            .querySelectorAll('[data-summary]')
+            .forEach((el) => (el.textContent = formatNumber(summaryMap[el.dataset.summary] || 0)));
     }
 
     function renderChart(points) {
@@ -343,24 +423,26 @@
             return;
         }
 
-        const maxValue = Math.max(...points.map((p) => Math.max(p.running_count, p.suc_count, p.fail_count))) || 1;
+        const maxValue = Math.max(
+            ...points.map((p) => Math.max(p.runningCount ?? 0, p.sucCount ?? 0, p.failCount ?? 0)),
+            1,
+        );
         const stepX = chartWidth / Math.max(points.length - 1, 1);
 
         const colors = {
-            running_count: '#facc15',
-            suc_count: '#22c55e',
-            fail_count: '#f87171',
+            runningCount: '#facc15',
+            sucCount: '#22c55e',
+            failCount: '#f87171',
         };
 
-        const metrics = Object.keys(colors);
-
-        metrics.forEach((metric) => {
+        Object.keys(colors).forEach((metric) => {
             ctx.beginPath();
             ctx.strokeStyle = colors[metric];
             ctx.lineWidth = 2;
             points.forEach((point, index) => {
                 const x = axisX + stepX * index;
-                const yRatio = point[metric] / maxValue;
+                const value = point?.[metric] ?? 0;
+                const yRatio = value / maxValue;
                 const y = axisY - yRatio * chartHeight;
                 if (index === 0) {
                     ctx.moveTo(x, y);
@@ -375,33 +457,38 @@
         ctx.font = '12px "Inter", sans-serif';
         points.forEach((point, index) => {
             const x = axisX + stepX * index;
-            ctx.fillText(point.trigger_day, x - 24, height - 8);
+            ctx.fillText(point.triggerDay, x - 28, height - 8);
         });
     }
 
-    function renderTable(points) {
+    function renderChartTable(points) {
         if (!points.length) {
             chartTable.innerHTML = '<tr><td colspan="4" class="muted">暂无数据</td></tr>';
             return;
         }
         chartTable.innerHTML = points
-            .map((point) => `
-                <tr>
-                    <td>${point.trigger_day}</td>
-                    <td>${point.running_count.toLocaleString()}</td>
-                    <td>${point.suc_count.toLocaleString()}</td>
-                    <td>${point.fail_count.toLocaleString()}</td>
-                </tr>
-            `)
+            .map(
+                (point) => `
+                    <tr>
+                        <td>${point.triggerDay}</td>
+                        <td>${point.runningCount ?? 0}</td>
+                        <td>${point.sucCount ?? 0}</td>
+                        <td>${point.failCount ?? 0}</td>
+                    </tr>
+                `,
+            )
             .join('');
     }
 
-    function showToast(message) {
+    function formatNumber(value) {
+        return new Intl.NumberFormat('zh-CN').format(value);
+    }
+
+    function showToast(message, error = false) {
         toast.textContent = message;
+        toast.classList.toggle('error', error);
         toast.classList.add('show');
         setTimeout(() => toast.classList.remove('show'), 3200);
     }
-
-    loadDashboard();
 </script>
 {% endblock %}

--- a/rust-admin/templates/job-groups.html
+++ b/rust-admin/templates/job-groups.html
@@ -1,0 +1,729 @@
+{% extends "layout.html" %}
+
+{% block sidebar %}
+<aside class="sidebar card">
+    <div class="sidebar-header">
+        <div class="sidebar-title">{{ app_name }}</div>
+        <div class="sidebar-subtitle muted">分布式任务调度中心</div>
+    </div>
+    <nav class="sidebar-nav">
+        <a class="nav-link" href="/admin/dashboard">仪表盘</a>
+        <a class="nav-link" href="/admin/jobs">任务管理</a>
+        <a class="nav-link{% if active_nav == "groups" %} is-active{% endif %}" href="/admin/groups">执行器管理</a>
+        <a class="nav-link" href="/admin/logs">任务日志</a>
+    </nav>
+</aside>
+{% endblock %}
+
+{% block head %}
+<style>
+    :root {
+        --border-color: rgba(148, 163, 184, 0.18);
+        --muted: rgba(226, 232, 240, 0.75);
+        --accent: #38bdf8;
+    }
+
+    .sidebar {
+        width: 240px;
+        padding: 26px 22px;
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+    }
+
+    .sidebar-header {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+    }
+
+    .sidebar-title {
+        font-size: 18px;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+    }
+
+    .sidebar-subtitle {
+        font-size: 13px;
+    }
+
+    .sidebar-nav {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+    }
+
+    .nav-link {
+        display: block;
+        width: 100%;
+        padding: 12px 14px;
+        border-radius: 12px;
+        border: 1px solid transparent;
+        background: rgba(148, 163, 184, 0.08);
+        color: inherit;
+        text-decoration: none;
+        font-weight: 600;
+        transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+    }
+
+    .nav-link:hover {
+        background: rgba(56, 189, 248, 0.18);
+        border-color: rgba(56, 189, 248, 0.45);
+        transform: translateX(2px);
+    }
+
+    .nav-link.is-active {
+        background: linear-gradient(135deg, rgba(14, 165, 233, 0.22), rgba(37, 99, 235, 0.28));
+        border-color: rgba(59, 130, 246, 0.55);
+        box-shadow: 0 12px 24px rgba(37, 99, 235, 0.25);
+    }
+
+    .page-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 24px 28px;
+        border-radius: 18px;
+        border: 1px solid var(--border-color);
+        background: rgba(15, 23, 42, 0.8);
+        margin-bottom: 24px;
+    }
+
+    .page-header h1 {
+        margin: 0;
+        font-size: 22px;
+        letter-spacing: 0.06em;
+    }
+
+    .user-info {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        font-size: 14px;
+        color: rgba(226, 232, 240, 0.8);
+    }
+
+    .section-card {
+        padding: 24px 28px;
+        border-radius: 18px;
+        border: 1px solid var(--border-color);
+        background: rgba(15, 23, 42, 0.78);
+        display: flex;
+        flex-direction: column;
+        gap: 20px;
+    }
+
+    .section-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 16px;
+    }
+
+    .section-actions {
+        display: flex;
+        gap: 12px;
+    }
+
+    .section-actions button,
+    .filter-grid button {
+        background: rgba(148, 163, 184, 0.15);
+        border: 1px solid rgba(148, 163, 184, 0.3);
+        color: inherit;
+        padding: 8px 14px;
+        border-radius: 10px;
+        font-size: 13px;
+    }
+
+    .filter-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        gap: 12px 18px;
+        align-items: end;
+    }
+
+    .filter-grid label {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        font-size: 13px;
+    }
+
+    .form-actions {
+        display: flex;
+        gap: 10px;
+    }
+
+    .filter-grid input,
+    .filter-grid select,
+    .modal-body input,
+    .modal-body textarea,
+    .modal-body select {
+        padding: 8px 10px;
+        border-radius: 8px;
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        background: rgba(15, 23, 42, 0.65);
+        color: inherit;
+        font: inherit;
+    }
+
+    table {
+        width: 100%;
+        border-collapse: collapse;
+    }
+
+    th,
+    td {
+        text-align: left;
+        padding: 10px 0;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+        vertical-align: top;
+    }
+
+    .table-actions {
+        display: inline-flex;
+        gap: 8px;
+    }
+
+    .table-actions button {
+        background: transparent;
+        border: 1px solid rgba(148, 163, 184, 0.32);
+        color: inherit;
+        padding: 4px 10px;
+        border-radius: 8px;
+        font-size: 12px;
+    }
+
+    .table-footer {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        font-size: 12px;
+        color: var(--muted);
+    }
+
+    .pager {
+        display: inline-flex;
+        gap: 8px;
+    }
+
+    .pager button[disabled] {
+        opacity: 0.4;
+        cursor: not-allowed;
+    }
+
+    .modal {
+        position: fixed;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 999;
+    }
+
+    .modal.hidden {
+        display: none;
+    }
+
+    .modal-backdrop {
+        position: absolute;
+        inset: 0;
+        background: rgba(15, 23, 42, 0.65);
+        backdrop-filter: blur(6px);
+    }
+
+    .modal-content {
+        position: relative;
+        width: min(720px, 92vw);
+        max-height: 90vh;
+        overflow-y: auto;
+        padding: 28px 30px;
+        display: flex;
+        flex-direction: column;
+        gap: 20px;
+    }
+
+    .modal-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    }
+
+    .modal-header h3 {
+        margin: 0;
+    }
+
+    .modal-close {
+        background: transparent;
+        border: none;
+        color: inherit;
+        font-size: 24px;
+        line-height: 1;
+        cursor: pointer;
+    }
+
+    .modal-body {
+        display: grid;
+        gap: 16px;
+    }
+
+    .modal-footer {
+        display: flex;
+        justify-content: flex-end;
+        gap: 12px;
+    }
+
+    .modal-footer button {
+        padding: 10px 18px;
+        border-radius: 10px;
+        border: 1px solid rgba(148, 163, 184, 0.4);
+        background: rgba(148, 163, 184, 0.18);
+        color: inherit;
+        font-size: 14px;
+    }
+
+    .toast {
+        position: fixed;
+        top: 24px;
+        right: 24px;
+        padding: 12px 16px;
+        border-radius: 12px;
+        background: rgba(56, 189, 248, 0.85);
+        color: white;
+        box-shadow: 0 10px 30px rgba(56, 189, 248, 0.35);
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.3s ease;
+        z-index: 1200;
+    }
+
+    .toast.error {
+        background: rgba(239, 68, 68, 0.85);
+        box-shadow: 0 10px 30px rgba(239, 68, 68, 0.35);
+    }
+
+    .toast.show {
+        opacity: 1;
+        pointer-events: auto;
+    }
+
+    @media (max-width: 1024px) {
+        .page-layout {
+            flex-direction: column;
+        }
+
+        .sidebar {
+            width: 100%;
+        }
+
+        .sidebar-nav {
+            flex-direction: row;
+            flex-wrap: wrap;
+        }
+
+        .nav-link {
+            flex: 1 1 160px;
+        }
+    }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="page-header card">
+    <div>
+        <h1>执行器管理</h1>
+        <div class="muted">维护注册执行器与调度地址</div>
+    </div>
+    <div class="user-info">
+        <span id="welcome-user">--</span>
+        <button id="logout" type="button">退出登录</button>
+    </div>
+</div>
+
+<section class="section-card card">
+    <div class="section-header">
+        <div>
+            <h2>执行器列表</h2>
+            <div class="muted">支持新增、编辑与删除执行器</div>
+        </div>
+        <div class="section-actions">
+            <button id="open-group-modal" type="button">新增执行器</button>
+            <button id="reload-groups" type="button">刷新</button>
+        </div>
+    </div>
+    <form id="group-filter-form" class="filter-grid">
+        <label>
+            AppName
+            <input id="group-filter-app" type="text" placeholder="示例：xxl-job-executor" />
+        </label>
+        <label>
+            执行器标题
+            <input id="group-filter-title" type="text" placeholder="模糊匹配" />
+        </label>
+        <div class="form-actions">
+            <button type="submit">查询</button>
+            <button type="button" id="group-reset">重置</button>
+        </div>
+    </form>
+    <table>
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>AppName</th>
+                <th>标题</th>
+                <th>地址模式</th>
+                <th>地址列表</th>
+                <th>更新时间</th>
+                <th>操作</th>
+            </tr>
+        </thead>
+        <tbody id="group-table-body">
+            <tr>
+                <td colspan="7" class="muted">加载中...</td>
+            </tr>
+        </tbody>
+    </table>
+    <div class="table-footer">
+        <div>共 <span id="group-total">0</span> 个执行器</div>
+        <div class="pager">
+            <button type="button" id="group-prev">上一页</button>
+            <button type="button" id="group-next">下一页</button>
+        </div>
+    </div>
+</section>
+
+<div class="modal hidden" id="group-modal">
+    <div class="modal-backdrop" data-modal-close></div>
+    <div class="modal-content card">
+        <div class="modal-header">
+            <h3 id="group-modal-title">新增执行器</h3>
+            <button class="modal-close" type="button" data-modal-close>&times;</button>
+        </div>
+        <form id="group-form">
+            <div class="modal-body">
+                <label>
+                    AppName
+                    <input id="group-appname" name="appname" type="text" required minlength="4" maxlength="64" placeholder="至少 4 个字符" />
+                </label>
+                <label>
+                    执行器标题
+                    <input id="group-title" name="title" type="text" required />
+                </label>
+                <label>
+                    地址模式
+                    <select id="group-address-type" name="address_type">
+                        <option value="0">自动注册</option>
+                        <option value="1">手动录入</option>
+                    </select>
+                </label>
+                <label>
+                    地址列表 (多地址用换行分隔)
+                    <textarea id="group-address-list" name="address_list" placeholder="http://127.0.0.1:9999"></textarea>
+                </label>
+            </div>
+            <div class="modal-footer">
+                <button type="button" data-modal-close>取消</button>
+                <button type="submit">保存</button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div class="toast" id="toast"></div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+    const TOKEN_KEY = "xxl_admin_token";
+    const USERNAME_KEY = "xxl_admin_username";
+    const JOB_GROUPS_ENDPOINT = "{{ job_groups_endpoint }}";
+
+    const token = localStorage.getItem(TOKEN_KEY);
+    if (!token) {
+        window.location.replace("/admin/");
+    }
+
+    const welcomeUser = document.getElementById("welcome-user");
+    const logoutBtn = document.getElementById("logout");
+    const groupTableBody = document.getElementById("group-table-body");
+    const groupTotalEl = document.getElementById("group-total");
+    const groupModal = document.getElementById("group-modal");
+    const groupForm = document.getElementById("group-form");
+    const groupModalTitle = document.getElementById("group-modal-title");
+    const groupAddressType = document.getElementById("group-address-type");
+    const groupAddressList = document.getElementById("group-address-list");
+    const toast = document.getElementById("toast");
+
+    const groupFilters = {
+        appname: "",
+        title: "",
+        start: 0,
+        length: 10,
+    };
+
+    let groupEditingId = null;
+
+    welcomeUser.textContent = localStorage.getItem(USERNAME_KEY) || "未登录";
+    groupTotalEl.dataset.total = '0';
+    groupAddressList.disabled = groupAddressType.value === '0';
+
+    logoutBtn.addEventListener("click", () => {
+        localStorage.removeItem(TOKEN_KEY);
+        localStorage.removeItem(USERNAME_KEY);
+        window.location.replace("/admin/");
+    });
+
+    document.querySelectorAll('[data-modal-close]').forEach((el) => {
+        el.addEventListener('click', () => closeModal(el.closest('.modal')));
+    });
+
+    groupModal.addEventListener('click', (event) => {
+        if (event.target.classList.contains('modal-backdrop')) {
+            closeModal(groupModal);
+        }
+    });
+
+    document.getElementById('open-group-modal').addEventListener('click', () => {
+        groupEditingId = null;
+        groupForm.reset();
+        groupAddressList.disabled = groupAddressType.value === '0';
+        groupModalTitle.textContent = '新增执行器';
+        openModal(groupModal);
+    });
+
+    document.getElementById('reload-groups').addEventListener('click', () => loadGroups(true));
+
+    document.getElementById('group-filter-form').addEventListener('submit', (event) => {
+        event.preventDefault();
+        syncFilters();
+        loadGroups(true);
+    });
+
+    document.getElementById('group-reset').addEventListener('click', () => {
+        document.getElementById('group-filter-app').value = '';
+        document.getElementById('group-filter-title').value = '';
+        syncFilters();
+        loadGroups(true);
+    });
+
+    document.getElementById('group-prev').addEventListener('click', () => {
+        if (groupFilters.start >= groupFilters.length) {
+            groupFilters.start -= groupFilters.length;
+            loadGroups();
+        }
+    });
+
+    document.getElementById('group-next').addEventListener('click', () => {
+        const total = Number(groupTotalEl.dataset.total || 0);
+        if (groupFilters.start + groupFilters.length < total) {
+            groupFilters.start += groupFilters.length;
+            loadGroups();
+        }
+    });
+
+    groupAddressType.addEventListener('change', () => {
+        const isAuto = groupAddressType.value === '0';
+        groupAddressList.disabled = isAuto;
+        if (isAuto) {
+            groupAddressList.value = '';
+        }
+    });
+
+    groupForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        const formData = new FormData(groupForm);
+        const payload = {
+            appname: formData.get('appname').trim(),
+            title: formData.get('title').trim(),
+            address_type: Number(formData.get('address_type')),
+            address_list: formData.get('address_list')?.trim() || null,
+        };
+        if (payload.address_type === 0) {
+            payload.address_list = null;
+        }
+        try {
+            if (groupEditingId) {
+                await fetchJson(`${JOB_GROUPS_ENDPOINT}/${groupEditingId}`, {
+                    method: 'PUT',
+                    body: JSON.stringify(payload),
+                });
+                showToast('执行器已更新');
+            } else {
+                await fetchJson(JOB_GROUPS_ENDPOINT, {
+                    method: 'POST',
+                    body: JSON.stringify(payload),
+                });
+                showToast('执行器已创建');
+            }
+            closeModal(groupModal);
+            loadGroups(true);
+        } catch (error) {
+            showToast(error.message || '保存失败', true);
+        }
+    });
+
+    groupTableBody.addEventListener('click', async (event) => {
+        const action = event.target.closest('[data-action]');
+        if (!action) {
+            return;
+        }
+        const id = Number(action.dataset.id);
+        if (action.dataset.action === 'edit') {
+            try {
+                const group = await fetchJson(`${JOB_GROUPS_ENDPOINT}/${id}`);
+                groupEditingId = id;
+                groupModalTitle.textContent = `编辑执行器 #${id}`;
+                groupForm.appname.value = group.appname;
+                groupForm.title.value = group.title;
+                groupForm.address_type.value = String(group.addressType);
+                groupAddressList.value = group.addressList || '';
+                groupAddressList.disabled = group.addressType === 0;
+                openModal(groupModal);
+            } catch (error) {
+                showToast(error.message || '加载执行器失败', true);
+            }
+        } else if (action.dataset.action === 'delete') {
+            if (!confirm('确认删除该执行器？删除后将无法调度关联任务。')) {
+                return;
+            }
+            try {
+                await fetchJson(`${JOB_GROUPS_ENDPOINT}/${id}`, { method: 'DELETE' });
+                showToast('执行器已删除');
+                loadGroups(true);
+            } catch (error) {
+                showToast(error.message || '删除失败', true);
+            }
+        }
+    });
+
+    loadGroups();
+
+    function syncFilters() {
+        groupFilters.appname = document.getElementById('group-filter-app').value.trim();
+        groupFilters.title = document.getElementById('group-filter-title').value.trim();
+        groupFilters.start = 0;
+    }
+
+    async function loadGroups(resetStart = false) {
+        if (resetStart) {
+            groupFilters.start = 0;
+        }
+        const params = new URLSearchParams({
+            start: String(groupFilters.start),
+            length: String(groupFilters.length),
+        });
+        if (groupFilters.appname) {
+            params.set('appname', groupFilters.appname);
+        }
+        if (groupFilters.title) {
+            params.set('title', groupFilters.title);
+        }
+        groupTableBody.innerHTML = '<tr><td colspan="7" class="muted">加载中...</td></tr>';
+        try {
+            const result = await fetchJson(`${JOB_GROUPS_ENDPOINT}?${params.toString()}`);
+            const groups = Array.isArray(result.data) ? result.data : [];
+            const total = result.records_total ?? groups.length;
+            groupTotalEl.textContent = total;
+            groupTotalEl.dataset.total = String(total);
+            renderGroupTable(groups);
+        } catch (error) {
+            groupTableBody.innerHTML = `<tr><td colspan="7" class="muted">${escapeHtml(error.message || '加载失败')}</td></tr>`;
+        }
+    }
+
+    function renderGroupTable(groups) {
+        if (!groups.length) {
+            groupTableBody.innerHTML = '<tr><td colspan="7" class="muted">暂无执行器</td></tr>';
+            groupTotalEl.dataset.total = '0';
+            return;
+        }
+        groupTableBody.innerHTML = groups
+            .map((group) => `
+                <tr>
+                    <td>${group.id}</td>
+                    <td>${escapeHtml(group.appname)}</td>
+                    <td>${escapeHtml(group.title)}</td>
+                    <td>${group.addressType === 0 ? '自动注册' : '手动录入'}</td>
+                    <td>${group.addressList ? escapeHtml(group.addressList).replace(/\n/g, '<br>') : '--'}</td>
+                    <td>${displayDateTime(group.updateTime)}</td>
+                    <td>
+                        <div class="table-actions">
+                            <button type="button" data-action="edit" data-id="${group.id}">编辑</button>
+                            <button type="button" data-action="delete" data-id="${group.id}">删除</button>
+                        </div>
+                    </td>
+                </tr>
+            `)
+            .join('');
+    }
+
+    async function fetchJson(url, options = {}) {
+        const response = await fetch(url, {
+            ...options,
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${token}`,
+                ...(options.headers || {}),
+            },
+        });
+        if (!response.ok) {
+            const message = await response.json().catch(() => ({}));
+            throw new Error(message.message || response.statusText);
+        }
+        return response.json();
+    }
+
+    function displayDateTime(value) {
+        if (!value) {
+            return '--';
+        }
+        try {
+            const date = new Date(value);
+            if (Number.isNaN(date.getTime())) {
+                return value;
+            }
+            return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')} ${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
+        } catch (error) {
+            return value;
+        }
+    }
+
+    function openModal(modal) {
+        modal.classList.remove('hidden');
+    }
+
+    function closeModal(modal) {
+        modal.classList.add('hidden');
+    }
+
+    function showToast(message, error = false) {
+        toast.textContent = message;
+        toast.classList.toggle('error', error);
+        toast.classList.add('show');
+        setTimeout(() => toast.classList.remove('show'), 3200);
+    }
+
+    function escapeHtml(value) {
+        if (value === null || value === undefined) {
+            return '';
+        }
+        return String(value).replace(/[&<>"']/g, (char) => {
+            switch (char) {
+                case '&':
+                    return '&amp;';
+                case '<':
+                    return '&lt;';
+                case '>':
+                    return '&gt;';
+                case '"':
+                    return '&quot;';
+                case "'":
+                    return '&#39;';
+                default:
+                    return char;
+            }
+        });
+    }
+</script>
+{% endblock %}

--- a/rust-admin/templates/job-info.html
+++ b/rust-admin/templates/job-info.html
@@ -1,0 +1,1106 @@
+{% extends "layout.html" %}
+
+{% block sidebar %}
+<aside class="sidebar card">
+    <div class="sidebar-header">
+        <div class="sidebar-title">{{ app_name }}</div>
+        <div class="sidebar-subtitle muted">分布式任务调度中心</div>
+    </div>
+    <nav class="sidebar-nav">
+        <a class="nav-link" href="/admin/dashboard">仪表盘</a>
+        <a class="nav-link{% if active_nav == "jobs" %} is-active{% endif %}" href="/admin/jobs">任务管理</a>
+        <a class="nav-link" href="/admin/groups">执行器管理</a>
+        <a class="nav-link" href="/admin/logs">任务日志</a>
+    </nav>
+</aside>
+{% endblock %}
+
+{% block head %}
+<style>
+    :root {
+        --border-color: rgba(148, 163, 184, 0.18);
+        --muted: rgba(226, 232, 240, 0.75);
+        --warning: #facc15;
+        --success: #22c55e;
+    }
+
+    .sidebar {
+        width: 240px;
+        padding: 26px 22px;
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+    }
+
+    .sidebar-header {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+    }
+
+    .sidebar-title {
+        font-size: 18px;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+    }
+
+    .sidebar-subtitle {
+        font-size: 13px;
+    }
+
+    .sidebar-nav {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+    }
+
+    .nav-link {
+        display: block;
+        width: 100%;
+        padding: 12px 14px;
+        border-radius: 12px;
+        border: 1px solid transparent;
+        background: rgba(148, 163, 184, 0.08);
+        color: inherit;
+        text-decoration: none;
+        font-weight: 600;
+        transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+    }
+
+    .nav-link:hover {
+        background: rgba(56, 189, 248, 0.18);
+        border-color: rgba(56, 189, 248, 0.45);
+        transform: translateX(2px);
+    }
+
+    .nav-link.is-active {
+        background: linear-gradient(135deg, rgba(14, 165, 233, 0.22), rgba(37, 99, 235, 0.28));
+        border-color: rgba(59, 130, 246, 0.55);
+        box-shadow: 0 12px 24px rgba(37, 99, 235, 0.25);
+    }
+
+    .page-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 24px 28px;
+        border-radius: 18px;
+        border: 1px solid var(--border-color);
+        background: rgba(15, 23, 42, 0.8);
+        margin-bottom: 24px;
+    }
+
+    .page-header h1 {
+        margin: 0;
+        font-size: 22px;
+        letter-spacing: 0.06em;
+    }
+
+    .user-info {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        font-size: 14px;
+        color: rgba(226, 232, 240, 0.8);
+    }
+
+    .section-card {
+        padding: 24px 28px;
+        border-radius: 18px;
+        border: 1px solid var(--border-color);
+        background: rgba(15, 23, 42, 0.78);
+        display: flex;
+        flex-direction: column;
+        gap: 20px;
+    }
+
+    .section-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 16px;
+    }
+
+    .section-actions {
+        display: flex;
+        gap: 12px;
+    }
+
+    .section-actions button,
+    .filter-grid button {
+        background: rgba(148, 163, 184, 0.15);
+        border: 1px solid rgba(148, 163, 184, 0.3);
+        color: inherit;
+        padding: 8px 14px;
+        border-radius: 10px;
+        font-size: 13px;
+    }
+
+    .filter-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        gap: 12px 18px;
+        align-items: end;
+    }
+
+    .filter-grid label {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        font-size: 13px;
+    }
+
+    .form-actions {
+        display: flex;
+        gap: 10px;
+    }
+
+    .filter-grid input,
+    .filter-grid select,
+    .modal-body input,
+    .modal-body textarea,
+    .modal-body select {
+        padding: 8px 10px;
+        border-radius: 8px;
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        background: rgba(15, 23, 42, 0.65);
+        color: inherit;
+        font: inherit;
+    }
+
+    table {
+        width: 100%;
+        border-collapse: collapse;
+    }
+
+    th,
+    td {
+        text-align: left;
+        padding: 10px 0;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+        vertical-align: middle;
+    }
+
+    .status-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 2px 10px;
+        border-radius: 999px;
+        font-size: 12px;
+        background: rgba(148, 163, 184, 0.15);
+    }
+
+    .status-badge[data-status="running"] {
+        background: rgba(250, 204, 21, 0.2);
+        color: var(--warning);
+    }
+
+    .status-badge[data-status="stopped"] {
+        background: rgba(148, 163, 184, 0.12);
+    }
+
+    .table-actions {
+        display: inline-flex;
+        gap: 8px;
+        flex-wrap: wrap;
+    }
+
+    .table-actions button {
+        background: transparent;
+        border: 1px solid rgba(148, 163, 184, 0.32);
+        color: inherit;
+        padding: 4px 10px;
+        border-radius: 8px;
+        font-size: 12px;
+    }
+
+    .table-footer {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        font-size: 12px;
+        color: var(--muted);
+    }
+
+    .pager {
+        display: inline-flex;
+        gap: 8px;
+    }
+
+    .pager button[disabled] {
+        opacity: 0.4;
+        cursor: not-allowed;
+    }
+
+    .modal {
+        position: fixed;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 999;
+    }
+
+    .modal.hidden {
+        display: none;
+    }
+
+    .modal-backdrop {
+        position: absolute;
+        inset: 0;
+        background: rgba(15, 23, 42, 0.65);
+        backdrop-filter: blur(6px);
+    }
+
+    .modal-content {
+        position: relative;
+        width: min(900px, 94vw);
+        max-height: 90vh;
+        overflow-y: auto;
+        padding: 28px 30px;
+        display: flex;
+        flex-direction: column;
+        gap: 20px;
+    }
+
+    .modal-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    }
+
+    .modal-header h3 {
+        margin: 0;
+    }
+
+    .modal-close {
+        background: transparent;
+        border: none;
+        color: inherit;
+        font-size: 24px;
+        line-height: 1;
+        cursor: pointer;
+    }
+
+    .modal-body {
+        display: grid;
+        gap: 18px;
+    }
+
+    .form-grid {
+        display: grid;
+        gap: 12px 16px;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+
+    .form-grid textarea {
+        min-height: 80px;
+        resize: vertical;
+    }
+
+    .trigger-preview {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+    }
+
+    .modal-footer {
+        display: flex;
+        justify-content: flex-end;
+        gap: 12px;
+    }
+
+    .modal-footer button {
+        padding: 10px 18px;
+        border-radius: 10px;
+        border: 1px solid rgba(148, 163, 184, 0.4);
+        background: rgba(148, 163, 184, 0.18);
+        color: inherit;
+        font-size: 14px;
+    }
+
+    .toast {
+        position: fixed;
+        top: 24px;
+        right: 24px;
+        padding: 12px 16px;
+        border-radius: 12px;
+        background: rgba(56, 189, 248, 0.85);
+        color: white;
+        box-shadow: 0 10px 30px rgba(56, 189, 248, 0.35);
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.3s ease;
+        z-index: 1200;
+    }
+
+    .toast.error {
+        background: rgba(239, 68, 68, 0.85);
+        box-shadow: 0 10px 30px rgba(239, 68, 68, 0.35);
+    }
+
+    .toast.show {
+        opacity: 1;
+        pointer-events: auto;
+    }
+
+    @media (max-width: 1024px) {
+        .page-layout {
+            flex-direction: column;
+        }
+
+        .sidebar {
+            width: 100%;
+        }
+
+        .sidebar-nav {
+            flex-direction: row;
+            flex-wrap: wrap;
+        }
+
+        .nav-link {
+            flex: 1 1 160px;
+        }
+    }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="page-header card">
+    <div>
+        <h1>任务管理</h1>
+        <div class="muted">按执行器维护调度任务，支持新增、编辑、启停与手动触发</div>
+    </div>
+    <div class="user-info">
+        <span id="welcome-user">--</span>
+        <button id="logout" type="button">退出登录</button>
+    </div>
+</div>
+
+<section class="section-card card">
+    <div class="section-header">
+        <div>
+            <h2>任务列表</h2>
+            <div class="muted">查看任务状态并执行操作</div>
+        </div>
+        <div class="section-actions">
+            <button id="open-job-modal" type="button">新增任务</button>
+            <button id="reload-jobs" type="button">刷新</button>
+        </div>
+    </div>
+    <form id="job-filter-form" class="filter-grid">
+        <label>
+            执行器
+            <select id="job-filter-group" required></select>
+        </label>
+        <label>
+            任务状态
+            <select id="job-filter-status">
+                <option value="">全部</option>
+                <option value="1">运行中</option>
+                <option value="0">停止</option>
+            </select>
+        </label>
+        <label>
+            任务描述
+            <input id="job-filter-desc" type="text" placeholder="模糊匹配" />
+        </label>
+        <label>
+            Handler
+            <input id="job-filter-handler" type="text" placeholder="执行器 Handler" />
+        </label>
+        <label>
+            负责人
+            <input id="job-filter-author" type="text" placeholder="维护人" />
+        </label>
+        <div class="form-actions">
+            <button type="submit">查询</button>
+            <button type="button" id="job-reset">重置</button>
+        </div>
+    </form>
+    <table>
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>任务描述</th>
+                <th>调度方式</th>
+                <th>执行器</th>
+                <th>Handler</th>
+                <th>状态</th>
+                <th>下次调度</th>
+                <th>操作</th>
+            </tr>
+        </thead>
+        <tbody id="job-table-body">
+            <tr>
+                <td colspan="8" class="muted">请选择执行器</td>
+            </tr>
+        </tbody>
+    </table>
+    <div class="table-footer">
+        <div>共 <span id="job-total">0</span> 条记录</div>
+        <div class="pager">
+            <button type="button" id="job-prev">上一页</button>
+            <button type="button" id="job-next">下一页</button>
+        </div>
+    </div>
+</section>
+
+<div class="modal hidden" id="job-modal">
+    <div class="modal-backdrop" data-modal-close></div>
+    <div class="modal-content card">
+        <div class="modal-header">
+            <h3 id="job-modal-title">新增任务</h3>
+            <button class="modal-close" type="button" data-modal-close>&times;</button>
+        </div>
+        <form id="job-form">
+            <div class="modal-body">
+                <div class="form-grid">
+                    <label>
+                        执行器
+                        <select id="job-group" name="job_group" required></select>
+                    </label>
+                    <label>
+                        任务描述
+                        <input id="job-desc" name="job_desc" type="text" required />
+                    </label>
+                    <label>
+                        负责人
+                        <input id="job-author" name="author" type="text" placeholder="可选" />
+                    </label>
+                    <label>
+                        报警邮箱
+                        <input id="job-email" name="alarm_email" type="email" placeholder="多个以逗号分隔" />
+                    </label>
+                    <label>
+                        调度类型
+                        <select id="job-schedule-type" name="schedule_type">
+                            <option value="CRON">CRON</option>
+                            <option value="FIX_RATE">固定频率 (秒)</option>
+                            <option value="FIX_DELAY">固定延迟 (秒)</option>
+                            <option value="NONE">手动触发</option>
+                        </select>
+                    </label>
+                    <label>
+                        调度配置
+                        <input id="job-schedule-conf" name="schedule_conf" type="text" placeholder="CRON 表达式或秒数" />
+                    </label>
+                    <label>
+                        错过策略
+                        <select id="job-misfire" name="misfire_strategy">
+                            <option value="DO_NOTHING">忽略</option>
+                            <option value="FIRE_ONCE_NOW">立即执行一次</option>
+                        </select>
+                    </label>
+                    <label>
+                        路由策略
+                        <select id="job-route" name="executor_route_strategy">
+                            <option value="FIRST">第一个</option>
+                            <option value="LAST">最后一个</option>
+                            <option value="ROUND">轮询</option>
+                            <option value="RANDOM">随机</option>
+                            <option value="CONSISTENT_HASH">一致性 HASH</option>
+                            <option value="LEAST_FREQUENTLY_USED">最不经常使用</option>
+                            <option value="LEAST_RECENTLY_USED">最近最久未使用</option>
+                            <option value="FAILOVER">故障转移</option>
+                            <option value="BUSYOVER">忙碌转移</option>
+                            <option value="SHARDING_BROADCAST">分片广播</option>
+                        </select>
+                    </label>
+                    <label>
+                        阻塞策略
+                        <select id="job-block" name="executor_block_strategy">
+                            <option value="SERIAL_EXECUTION">单机串行</option>
+                            <option value="DISCARD_LATER">丢弃后续</option>
+                            <option value="COVER_EARLY">覆盖之前</option>
+                        </select>
+                    </label>
+                    <label>
+                        Handler
+                        <input id="job-handler" name="executor_handler" type="text" placeholder="示例：demoJobHandler" />
+                    </label>
+                    <label>
+                        任务参数
+                        <textarea id="job-param" name="executor_param" placeholder="JSON 或文本"></textarea>
+                    </label>
+                    <label>
+                        超时时间 (秒)
+                        <input id="job-timeout" name="executor_timeout" type="number" min="0" value="0" />
+                    </label>
+                    <label>
+                        失败重试次数
+                        <input id="job-retry" name="executor_fail_retry_count" type="number" min="0" value="0" />
+                    </label>
+                    <label>
+                        Glue 类型
+                        <select id="job-glue" name="glue_type">
+                            <option value="BEAN">BEAN</option>
+                            <option value="GLUE_GROOVY">GLUE Groovy</option>
+                            <option value="GLUE_SHELL">GLUE Shell</option>
+                            <option value="GLUE_PYTHON">GLUE Python</option>
+                            <option value="GLUE_PHP">GLUE PHP</option>
+                            <option value="GLUE_NODEJS">GLUE Nodejs</option>
+                            <option value="GLUE_POWERSHELL">GLUE PowerShell</option>
+                        </select>
+                    </label>
+                    <label>
+                        Glue 备注
+                        <input id="job-glue-remark" name="glue_remark" type="text" placeholder="可选" />
+                    </label>
+                    <label>
+                        子任务 ID
+                        <input id="job-child" name="child_jobid" type="text" placeholder="多个以逗号分隔" />
+                    </label>
+                </div>
+                <div class="trigger-preview">
+                    <button type="button" id="preview-trigger">预览最近执行时间</button>
+                    <div id="trigger-preview-list" class="muted" style="font-size: 13px;">--</div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" data-modal-close>取消</button>
+                <button type="submit">保存</button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div class="modal hidden" id="trigger-modal">
+    <div class="modal-backdrop" data-modal-close></div>
+    <div class="modal-content card" style="max-width: 520px;">
+        <div class="modal-header">
+            <h3>手动触发任务</h3>
+            <button class="modal-close" type="button" data-modal-close>&times;</button>
+        </div>
+        <form id="trigger-form">
+            <div class="modal-body form-grid">
+                <label>
+                    执行参数
+                    <textarea id="trigger-param" name="executor_param" placeholder="可选"></textarea>
+                </label>
+                <label>
+                    执行地址
+                    <input id="trigger-address" name="address_list" type="text" placeholder="留空表示自动选择" />
+                </label>
+            </div>
+            <div class="modal-footer">
+                <button type="button" data-modal-close>取消</button>
+                <button type="submit">立即触发</button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div class="toast" id="toast"></div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+    const TOKEN_KEY = "xxl_admin_token";
+    const USERNAME_KEY = "xxl_admin_username";
+    const JOB_GROUPS_ENDPOINT = "{{ job_groups_endpoint }}";
+    const JOB_INFO_ENDPOINT = "{{ job_info_endpoint }}";
+    const JOB_INFO_NEXT_TRIGGER_ENDPOINT = "{{ job_info_next_trigger_endpoint }}";
+
+    const token = localStorage.getItem(TOKEN_KEY);
+    if (!token) {
+        window.location.replace("/admin/");
+    }
+
+    const welcomeUser = document.getElementById("welcome-user");
+    const logoutBtn = document.getElementById("logout");
+    const jobTableBody = document.getElementById("job-table-body");
+    const jobTotalEl = document.getElementById("job-total");
+    const jobFilterForm = document.getElementById("job-filter-form");
+    const toast = document.getElementById("toast");
+    const jobGroupSelect = document.getElementById("job-filter-group");
+    const jobModalGroupSelect = document.getElementById("job-group");
+    const scheduleTypeSelect = document.getElementById("job-schedule-type");
+    const scheduleConfInput = document.getElementById("job-schedule-conf");
+    const triggerPreviewBtn = document.getElementById("preview-trigger");
+    const triggerPreviewList = document.getElementById("trigger-preview-list");
+    const jobModal = document.getElementById("job-modal");
+    const jobForm = document.getElementById("job-form");
+    const jobModalTitle = document.getElementById("job-modal-title");
+    const triggerModal = document.getElementById("trigger-modal");
+    const triggerForm = document.getElementById("trigger-form");
+
+    const jobFilters = {
+        job_group: "",
+        trigger_status: "",
+        job_desc: "",
+        executor_handler: "",
+        author: "",
+        start: 0,
+        length: 10,
+    };
+
+    const state = {
+        groupOptions: [],
+    };
+
+    let jobEditingId = null;
+    let triggerTargetJobId = null;
+    let currentJobs = [];
+
+    welcomeUser.textContent = localStorage.getItem(USERNAME_KEY) || "未登录";
+    jobTotalEl.dataset.total = '0';
+
+    logoutBtn.addEventListener("click", () => {
+        localStorage.removeItem(TOKEN_KEY);
+        localStorage.removeItem(USERNAME_KEY);
+        window.location.replace("/admin/");
+    });
+
+    document.querySelectorAll('[data-modal-close]').forEach((el) => {
+        el.addEventListener('click', () => closeModal(el.closest('.modal')));
+    });
+
+    document.querySelectorAll('.modal').forEach((modal) => {
+        modal.addEventListener('click', (event) => {
+            if (event.target.classList.contains('modal-backdrop')) {
+                closeModal(modal);
+            }
+        });
+    });
+
+    document.getElementById('open-job-modal').addEventListener('click', () => {
+        jobEditingId = null;
+        jobForm.reset();
+        triggerPreviewList.textContent = '--';
+        jobModalTitle.textContent = '新增任务';
+        if (jobFilters.job_group) {
+            jobModalGroupSelect.value = jobFilters.job_group;
+        }
+        handleScheduleTypeChange();
+        openModal(jobModal);
+    });
+
+    document.getElementById('reload-jobs').addEventListener('click', () => {
+        syncFilters();
+        loadJobs(true);
+    });
+
+    jobFilterForm.addEventListener('submit', (event) => {
+        event.preventDefault();
+        syncFilters();
+        loadJobs(true);
+    });
+
+    document.getElementById('job-reset').addEventListener('click', () => {
+        document.getElementById('job-filter-status').value = '';
+        document.getElementById('job-filter-desc').value = '';
+        document.getElementById('job-filter-handler').value = '';
+        document.getElementById('job-filter-author').value = '';
+        syncFilters();
+        loadJobs(true);
+    });
+
+    document.getElementById('job-prev').addEventListener('click', () => {
+        if (jobFilters.start >= jobFilters.length) {
+            jobFilters.start -= jobFilters.length;
+            loadJobs();
+        }
+    });
+
+    document.getElementById('job-next').addEventListener('click', () => {
+        const total = Number(jobTotalEl.dataset.total || 0);
+        if (jobFilters.start + jobFilters.length < total) {
+            jobFilters.start += jobFilters.length;
+            loadJobs();
+        }
+    });
+
+    scheduleTypeSelect.addEventListener('change', handleScheduleTypeChange);
+
+    triggerPreviewBtn.addEventListener('click', async () => {
+        try {
+            const params = new URLSearchParams({
+                scheduleType: scheduleTypeSelect.value,
+                scheduleConf: scheduleConfInput.value,
+            });
+            const previews = await fetchJson(`${JOB_INFO_NEXT_TRIGGER_ENDPOINT}?${params.toString()}`);
+            triggerPreviewList.textContent = Array.isArray(previews) && previews.length
+                ? previews.join('，')
+                : '暂无可用执行时间';
+        } catch (error) {
+            triggerPreviewList.textContent = error.message || '预览失败';
+        }
+    });
+
+    jobForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        const formData = new FormData(jobForm);
+        const payload = {
+            job_group: Number(formData.get('job_group')),
+            job_desc: formData.get('job_desc').trim(),
+            author: optionalValue(formData.get('author')),
+            alarm_email: optionalValue(formData.get('alarm_email')),
+            schedule_type: formData.get('schedule_type'),
+            schedule_conf: optionalValue(formData.get('schedule_conf')),
+            misfire_strategy: formData.get('misfire_strategy'),
+            executor_route_strategy: optionalValue(formData.get('executor_route_strategy')),
+            executor_handler: optionalValue(formData.get('executor_handler')),
+            executor_param: optionalValue(formData.get('executor_param')),
+            executor_block_strategy: optionalValue(formData.get('executor_block_strategy')),
+            executor_timeout: numberValue(formData.get('executor_timeout')),
+            executor_fail_retry_count: numberValue(formData.get('executor_fail_retry_count')),
+            glue_type: formData.get('glue_type'),
+            glue_remark: optionalValue(formData.get('glue_remark')),
+            child_jobid: optionalValue(formData.get('child_jobid')),
+        };
+        try {
+            if (jobEditingId) {
+                await fetchJson(`${JOB_INFO_ENDPOINT}/${jobEditingId}`, {
+                    method: 'PUT',
+                    body: JSON.stringify(payload),
+                });
+                showToast('任务已更新');
+            } else {
+                await fetchJson(JOB_INFO_ENDPOINT, {
+                    method: 'POST',
+                    body: JSON.stringify(payload),
+                });
+                showToast('任务已创建');
+            }
+            closeModal(jobModal);
+            loadJobs(true);
+        } catch (error) {
+            showToast(error.message || '保存失败', true);
+        }
+    });
+
+    triggerForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        if (!triggerTargetJobId) {
+            showToast('未找到任务信息', true);
+            return;
+        }
+        const formData = new FormData(triggerForm);
+        const payload = {
+            executor_param: optionalValue(formData.get('executor_param')),
+            address_list: optionalValue(formData.get('address_list')),
+        };
+        try {
+            await fetchJson(`${JOB_INFO_ENDPOINT}/${triggerTargetJobId}/trigger`, {
+                method: 'POST',
+                body: JSON.stringify(payload),
+            });
+            showToast('任务已触发');
+            closeModal(triggerModal);
+        } catch (error) {
+            showToast(error.message || '触发失败', true);
+        }
+    });
+
+    jobTableBody.addEventListener('click', async (event) => {
+        const action = event.target.closest('[data-action]');
+        if (!action) {
+            return;
+        }
+        const id = Number(action.dataset.id);
+        const job = currentJobs.find((item) => item.id === id);
+        if (!job) {
+            return;
+        }
+        switch (action.dataset.action) {
+            case 'edit':
+                jobEditingId = id;
+                jobModalTitle.textContent = `编辑任务 #${id}`;
+                fillJobForm(job);
+                openModal(jobModal);
+                break;
+            case 'delete':
+                if (confirm('确认删除该任务？')) {
+                    try {
+                        await fetchJson(`${JOB_INFO_ENDPOINT}/${id}`, { method: 'DELETE' });
+                        showToast('任务已删除');
+                        loadJobs(true);
+                    } catch (error) {
+                        showToast(error.message || '删除失败', true);
+                    }
+                }
+                break;
+            case 'start':
+                try {
+                    await fetchJson(`${JOB_INFO_ENDPOINT}/${id}/start`, { method: 'POST' });
+                    showToast('任务已启动');
+                    loadJobs();
+                } catch (error) {
+                    showToast(error.message || '操作失败', true);
+                }
+                break;
+            case 'stop':
+                try {
+                    await fetchJson(`${JOB_INFO_ENDPOINT}/${id}/stop`, { method: 'POST' });
+                    showToast('任务已停止');
+                    loadJobs();
+                } catch (error) {
+                    showToast(error.message || '操作失败', true);
+                }
+                break;
+            case 'trigger':
+                triggerTargetJobId = id;
+                triggerForm.reset();
+                openModal(triggerModal);
+                break;
+        }
+    });
+
+    refreshGroupOptions().then(() => {
+        syncFilters();
+        if (jobFilters.job_group) {
+            loadJobs(true);
+        } else {
+            jobTableBody.innerHTML = '<tr><td colspan="8" class="muted">请先创建执行器</td></tr>';
+        }
+    });
+
+    function syncFilters() {
+        jobFilters.job_group = jobGroupSelect.value;
+        jobFilters.trigger_status = document.getElementById('job-filter-status').value;
+        jobFilters.job_desc = document.getElementById('job-filter-desc').value.trim();
+        jobFilters.executor_handler = document.getElementById('job-filter-handler').value.trim();
+        jobFilters.author = document.getElementById('job-filter-author').value.trim();
+        jobFilters.start = 0;
+    }
+
+    async function refreshGroupOptions() {
+        try {
+            const params = new URLSearchParams({ start: '0', length: '200' });
+            const result = await fetchJson(`${JOB_GROUPS_ENDPOINT}?${params.toString()}`);
+            state.groupOptions = Array.isArray(result.data) ? result.data : [];
+        } catch (error) {
+            state.groupOptions = [];
+            showToast(error.message || '加载执行器失败', true);
+        }
+        updateGroupSelects();
+    }
+
+    function updateGroupSelects() {
+        const selects = [jobGroupSelect, jobModalGroupSelect];
+        selects.forEach((select) => {
+            if (!select) {
+                return;
+            }
+            const previous = select.value;
+            select.innerHTML = state.groupOptions
+                .map((group) => `<option value="${group.id}">${group.id} - ${escapeHtml(group.appname)}</option>`)
+                .join('');
+            if (!state.groupOptions.length) {
+                select.innerHTML = '<option value="">无执行器</option>';
+                select.value = '';
+                select.disabled = true;
+            } else if (previous && state.groupOptions.some((group) => String(group.id) === previous)) {
+                select.value = previous;
+                select.disabled = false;
+            } else {
+                select.value = String(state.groupOptions[0].id);
+                select.disabled = false;
+            }
+        });
+        if (jobGroupSelect) {
+            jobFilters.job_group = jobGroupSelect.value;
+        }
+    }
+
+    async function loadJobs(resetStart = false) {
+        if (!jobFilters.job_group) {
+            jobTableBody.innerHTML = '<tr><td colspan="8" class="muted">请选择执行器</td></tr>';
+            jobTotalEl.textContent = '0';
+            jobTotalEl.dataset.total = '0';
+            return;
+        }
+        if (resetStart) {
+            jobFilters.start = 0;
+        }
+        const params = new URLSearchParams({
+            start: String(jobFilters.start),
+            length: String(jobFilters.length),
+            job_group: jobFilters.job_group,
+        });
+        if (jobFilters.trigger_status) {
+            params.set('trigger_status', jobFilters.trigger_status);
+        }
+        if (jobFilters.job_desc) {
+            params.set('job_desc', jobFilters.job_desc);
+        }
+        if (jobFilters.executor_handler) {
+            params.set('executor_handler', jobFilters.executor_handler);
+        }
+        if (jobFilters.author) {
+            params.set('author', jobFilters.author);
+        }
+        jobTableBody.innerHTML = '<tr><td colspan="8" class="muted">加载中...</td></tr>';
+        try {
+            const result = await fetchJson(`${JOB_INFO_ENDPOINT}?${params.toString()}`);
+            currentJobs = Array.isArray(result.data) ? result.data : [];
+            const total = result.records_total ?? currentJobs.length;
+            jobTotalEl.textContent = total;
+            jobTotalEl.dataset.total = String(total);
+            renderJobTable(currentJobs);
+        } catch (error) {
+            jobTableBody.innerHTML = `<tr><td colspan="8" class="muted">${escapeHtml(error.message || '加载失败')}</td></tr>`;
+        }
+    }
+
+    function renderJobTable(jobs) {
+        if (!jobs.length) {
+            jobTableBody.innerHTML = '<tr><td colspan="8" class="muted">暂无任务</td></tr>';
+            return;
+        }
+        jobTableBody.innerHTML = jobs
+            .map((job) => {
+                const status = job.triggerStatus === 1 ? 'running' : 'stopped';
+                const statusText = status === 'running' ? '运行中' : '停止';
+                return `
+                    <tr>
+                        <td>${job.id}</td>
+                        <td>${escapeHtml(job.jobDesc || '--')}</td>
+                        <td>${formatSchedule(job)}</td>
+                        <td>${job.jobGroup}</td>
+                        <td>${escapeHtml(job.executorHandler || '--')}</td>
+                        <td><span class="status-badge" data-status="${status}">${statusText}</span></td>
+                        <td>${displayTimestamp(job.triggerNextTime)}</td>
+                        <td>
+                            <div class="table-actions">
+                                <button type="button" data-action="edit" data-id="${job.id}">编辑</button>
+                                <button type="button" data-action="${status === 'running' ? 'stop' : 'start'}" data-id="${job.id}">${status === 'running' ? '停止' : '启动'}</button>
+                                <button type="button" data-action="trigger" data-id="${job.id}">触发</button>
+                                <button type="button" data-action="delete" data-id="${job.id}">删除</button>
+                            </div>
+                        </td>
+                    </tr>
+                `;
+            })
+            .join('');
+    }
+
+    function fillJobForm(job) {
+        jobForm.job_group.value = job.jobGroup;
+        jobForm.job_desc.value = job.jobDesc || '';
+        jobForm.author.value = job.author || '';
+        jobForm.alarm_email.value = job.alarmEmail || '';
+        jobForm.schedule_type.value = job.scheduleType || 'CRON';
+        jobForm.schedule_conf.value = job.scheduleConf || '';
+        jobForm.misfire_strategy.value = job.misfireStrategy || 'DO_NOTHING';
+        jobForm.executor_route_strategy.value = job.executorRouteStrategy || 'FIRST';
+        jobForm.executor_handler.value = job.executorHandler || '';
+        jobForm.executor_param.value = job.executorParam || '';
+        jobForm.executor_block_strategy.value = job.executorBlockStrategy || 'SERIAL_EXECUTION';
+        jobForm.executor_timeout.value = job.executorTimeout ?? 0;
+        jobForm.executor_fail_retry_count.value = job.executorFailRetryCount ?? 0;
+        jobForm.glue_type.value = job.glueType || 'BEAN';
+        jobForm.glue_remark.value = job.glueRemark || '';
+        jobForm.child_jobid.value = job.childJobid || '';
+        triggerPreviewList.textContent = '--';
+        handleScheduleTypeChange();
+    }
+
+    function handleScheduleTypeChange() {
+        if (scheduleTypeSelect.value === 'NONE') {
+            scheduleConfInput.placeholder = '无需填写，任务需手动触发';
+            scheduleConfInput.disabled = true;
+            scheduleConfInput.value = '';
+        } else if (scheduleTypeSelect.value === 'CRON') {
+            scheduleConfInput.placeholder = '例如：0 0 * * * ?';
+            scheduleConfInput.disabled = false;
+        } else {
+            scheduleConfInput.placeholder = '请输入间隔秒数';
+            scheduleConfInput.disabled = false;
+        }
+    }
+
+    async function fetchJson(url, options = {}) {
+        const response = await fetch(url, {
+            ...options,
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${token}`,
+                ...(options.headers || {}),
+            },
+        });
+        if (!response.ok) {
+            const message = await response.json().catch(() => ({}));
+            throw new Error(message.message || response.statusText);
+        }
+        return response.json();
+    }
+
+    function optionalValue(value) {
+        const trimmed = value ? String(value).trim() : '';
+        return trimmed ? trimmed : null;
+    }
+
+    function numberValue(value) {
+        const num = Number(value);
+        return Number.isFinite(num) ? num : 0;
+    }
+
+    function displayTimestamp(timestamp) {
+        if (!timestamp) {
+            return '--';
+        }
+        const date = new Date(Number(timestamp));
+        if (Number.isNaN(date.getTime())) {
+            return '--';
+        }
+        return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')} ${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
+    }
+
+    function formatSchedule(job) {
+        if (job.scheduleType === 'NONE') {
+            return '手动触发';
+        }
+        if (job.scheduleType === 'CRON') {
+            return `CRON: ${escapeHtml(job.scheduleConf || '--')}`;
+        }
+        if (job.scheduleType === 'FIX_RATE') {
+            return `固定频率：${job.scheduleConf || '--'} 秒`;
+        }
+        if (job.scheduleType === 'FIX_DELAY') {
+            return `固定延迟：${job.scheduleConf || '--'} 秒`;
+        }
+        return escapeHtml(job.scheduleConf || '--');
+    }
+
+    function showToast(message, error = false) {
+        toast.textContent = message;
+        toast.classList.toggle('error', error);
+        toast.classList.add('show');
+        setTimeout(() => toast.classList.remove('show'), 3200);
+    }
+
+    function openModal(modal) {
+        modal.classList.remove('hidden');
+    }
+
+    function closeModal(modal) {
+        modal.classList.add('hidden');
+    }
+
+    function escapeHtml(value) {
+        if (value === null || value === undefined) {
+            return '';
+        }
+        return String(value).replace(/[&<>"']/g, (char) => {
+            switch (char) {
+                case '&':
+                    return '&amp;';
+                case '<':
+                    return '&lt;';
+                case '>':
+                    return '&gt;';
+                case '"':
+                    return '&quot;';
+                case "'":
+                    return '&#39;';
+                default:
+                    return char;
+            }
+        });
+    }
+</script>
+{% endblock %}

--- a/rust-admin/templates/job-logs.html
+++ b/rust-admin/templates/job-logs.html
@@ -1,0 +1,839 @@
+{% extends "layout.html" %}
+
+{% block sidebar %}
+<aside class="sidebar card">
+    <div class="sidebar-header">
+        <div class="sidebar-title">{{ app_name }}</div>
+        <div class="sidebar-subtitle muted">分布式任务调度中心</div>
+    </div>
+    <nav class="sidebar-nav">
+        <a class="nav-link" href="/admin/dashboard">仪表盘</a>
+        <a class="nav-link" href="/admin/jobs">任务管理</a>
+        <a class="nav-link" href="/admin/groups">执行器管理</a>
+        <a class="nav-link{% if active_nav == "logs" %} is-active{% endif %}" href="/admin/logs">任务日志</a>
+    </nav>
+</aside>
+{% endblock %}
+
+{% block head %}
+<style>
+    :root {
+        --border-color: rgba(148, 163, 184, 0.18);
+        --muted: rgba(226, 232, 240, 0.75);
+        --success: #22c55e;
+        --danger: #f87171;
+    }
+
+    .sidebar {
+        width: 240px;
+        padding: 26px 22px;
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+    }
+
+    .sidebar-header {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+    }
+
+    .sidebar-title {
+        font-size: 18px;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+    }
+
+    .sidebar-subtitle {
+        font-size: 13px;
+    }
+
+    .sidebar-nav {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+    }
+
+    .nav-link {
+        display: block;
+        width: 100%;
+        padding: 12px 14px;
+        border-radius: 12px;
+        border: 1px solid transparent;
+        background: rgba(148, 163, 184, 0.08);
+        color: inherit;
+        text-decoration: none;
+        font-weight: 600;
+        transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+    }
+
+    .nav-link:hover {
+        background: rgba(56, 189, 248, 0.18);
+        border-color: rgba(56, 189, 248, 0.45);
+        transform: translateX(2px);
+    }
+
+    .nav-link.is-active {
+        background: linear-gradient(135deg, rgba(14, 165, 233, 0.22), rgba(37, 99, 235, 0.28));
+        border-color: rgba(59, 130, 246, 0.55);
+        box-shadow: 0 12px 24px rgba(37, 99, 235, 0.25);
+    }
+
+    .page-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 24px 28px;
+        border-radius: 18px;
+        border: 1px solid var(--border-color);
+        background: rgba(15, 23, 42, 0.8);
+        margin-bottom: 24px;
+    }
+
+    .page-header h1 {
+        margin: 0;
+        font-size: 22px;
+        letter-spacing: 0.06em;
+    }
+
+    .user-info {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        font-size: 14px;
+        color: rgba(226, 232, 240, 0.8);
+    }
+
+    .section-card {
+        padding: 24px 28px;
+        border-radius: 18px;
+        border: 1px solid var(--border-color);
+        background: rgba(15, 23, 42, 0.78);
+        display: flex;
+        flex-direction: column;
+        gap: 20px;
+    }
+
+    .section-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 16px;
+    }
+
+    .section-actions {
+        display: flex;
+        gap: 12px;
+    }
+
+    .section-actions button,
+    .filter-grid button {
+        background: rgba(148, 163, 184, 0.15);
+        border: 1px solid rgba(148, 163, 184, 0.3);
+        color: inherit;
+        padding: 8px 14px;
+        border-radius: 10px;
+        font-size: 13px;
+    }
+
+    .filter-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        gap: 12px 18px;
+        align-items: end;
+    }
+
+    .filter-grid label {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        font-size: 13px;
+    }
+
+    .form-actions {
+        display: flex;
+        gap: 10px;
+    }
+
+    .filter-grid input,
+    .filter-grid select,
+    .modal-body input,
+    .modal-body textarea {
+        padding: 8px 10px;
+        border-radius: 8px;
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        background: rgba(15, 23, 42, 0.65);
+        color: inherit;
+        font: inherit;
+    }
+
+    table {
+        width: 100%;
+        border-collapse: collapse;
+    }
+
+    th,
+    td {
+        text-align: left;
+        padding: 10px 0;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+        vertical-align: top;
+    }
+
+    .status-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 2px 10px;
+        border-radius: 999px;
+        font-size: 12px;
+        background: rgba(148, 163, 184, 0.15);
+    }
+
+    .status-badge[data-status="success"] {
+        background: rgba(34, 197, 94, 0.18);
+        color: var(--success);
+    }
+
+    .status-badge[data-status="failed"] {
+        background: rgba(248, 113, 113, 0.18);
+        color: var(--danger);
+    }
+
+    .table-actions {
+        display: inline-flex;
+        gap: 8px;
+        flex-wrap: wrap;
+    }
+
+    .table-actions button {
+        background: transparent;
+        border: 1px solid rgba(148, 163, 184, 0.32);
+        color: inherit;
+        padding: 4px 10px;
+        border-radius: 8px;
+        font-size: 12px;
+    }
+
+    .table-footer {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        font-size: 12px;
+        color: var(--muted);
+    }
+
+    .pager {
+        display: inline-flex;
+        gap: 8px;
+    }
+
+    .pager button[disabled] {
+        opacity: 0.4;
+        cursor: not-allowed;
+    }
+
+    .modal {
+        position: fixed;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 999;
+    }
+
+    .modal.hidden {
+        display: none;
+    }
+
+    .modal-backdrop {
+        position: absolute;
+        inset: 0;
+        background: rgba(15, 23, 42, 0.65);
+        backdrop-filter: blur(6px);
+    }
+
+    .modal-content {
+        position: relative;
+        width: min(820px, 94vw);
+        max-height: 90vh;
+        overflow-y: auto;
+        padding: 28px 30px;
+        display: flex;
+        flex-direction: column;
+        gap: 20px;
+    }
+
+    .modal-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    }
+
+    .modal-header h3 {
+        margin: 0;
+    }
+
+    .modal-close {
+        background: transparent;
+        border: none;
+        color: inherit;
+        font-size: 24px;
+        line-height: 1;
+        cursor: pointer;
+    }
+
+    .modal-body {
+        display: grid;
+        gap: 18px;
+    }
+
+    .form-grid {
+        display: grid;
+        gap: 12px 16px;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+
+    .log-content {
+        background: rgba(15, 23, 42, 0.65);
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        border-radius: 12px;
+        padding: 16px;
+        white-space: pre-wrap;
+        max-height: 360px;
+        overflow-y: auto;
+    }
+
+    .modal-footer {
+        display: flex;
+        justify-content: flex-end;
+        gap: 12px;
+    }
+
+    .modal-footer button {
+        padding: 10px 18px;
+        border-radius: 10px;
+        border: 1px solid rgba(148, 163, 184, 0.4);
+        background: rgba(148, 163, 184, 0.18);
+        color: inherit;
+        font-size: 14px;
+    }
+
+    .toast {
+        position: fixed;
+        top: 24px;
+        right: 24px;
+        padding: 12px 16px;
+        border-radius: 12px;
+        background: rgba(56, 189, 248, 0.85);
+        color: white;
+        box-shadow: 0 10px 30px rgba(56, 189, 248, 0.35);
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.3s ease;
+        z-index: 1200;
+    }
+
+    .toast.error {
+        background: rgba(239, 68, 68, 0.85);
+        box-shadow: 0 10px 30px rgba(239, 68, 68, 0.35);
+    }
+
+    .toast.show {
+        opacity: 1;
+        pointer-events: auto;
+    }
+
+    @media (max-width: 1024px) {
+        .page-layout {
+            flex-direction: column;
+        }
+
+        .sidebar {
+            width: 100%;
+        }
+
+        .sidebar-nav {
+            flex-direction: row;
+            flex-wrap: wrap;
+        }
+
+        .nav-link {
+            flex: 1 1 160px;
+        }
+    }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="page-header card">
+    <div>
+        <h1>任务日志</h1>
+        <div class="muted">查询任务触发与执行日志，可查看详情或强制终止</div>
+    </div>
+    <div class="user-info">
+        <span id="welcome-user">--</span>
+        <button id="logout" type="button">退出登录</button>
+    </div>
+</div>
+
+<section class="section-card card">
+    <div class="section-header">
+        <div>
+            <h2>日志列表</h2>
+            <div class="muted">支持筛选执行器、任务、状态与时间范围</div>
+        </div>
+        <div class="section-actions">
+            <button id="clear-logs" type="button">清理日志</button>
+            <button id="reload-logs" type="button">刷新</button>
+        </div>
+    </div>
+    <form id="log-filter-form" class="filter-grid">
+        <label>
+            执行器
+            <select id="log-filter-group" required></select>
+        </label>
+        <label>
+            任务 ID
+            <input id="log-filter-job" type="number" min="0" placeholder="可选" />
+        </label>
+        <label>
+            日志状态
+            <select id="log-filter-status">
+                <option value="">全部</option>
+                <option value="1">成功</option>
+                <option value="2">失败</option>
+            </select>
+        </label>
+        <label>
+            开始时间
+            <input id="log-filter-start" type="datetime-local" />
+        </label>
+        <label>
+            结束时间
+            <input id="log-filter-end" type="datetime-local" />
+        </label>
+        <div class="form-actions">
+            <button type="submit">查询</button>
+            <button type="button" id="log-reset">重置</button>
+        </div>
+    </form>
+    <table>
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>任务 ID</th>
+                <th>执行器地址</th>
+                <th>Handler</th>
+                <th>触发时间</th>
+                <th>处理结果</th>
+                <th>操作</th>
+            </tr>
+        </thead>
+        <tbody id="log-table-body">
+            <tr>
+                <td colspan="7" class="muted">请选择执行器</td>
+            </tr>
+        </tbody>
+    </table>
+    <div class="table-footer">
+        <div>共 <span id="log-total">0</span> 条日志</div>
+        <div class="pager">
+            <button type="button" id="log-prev">上一页</button>
+            <button type="button" id="log-next">下一页</button>
+        </div>
+    </div>
+</section>
+
+<div class="modal hidden" id="log-modal">
+    <div class="modal-backdrop" data-modal-close></div>
+    <div class="modal-content card">
+        <div class="modal-header">
+            <h3>日志详情</h3>
+            <button class="modal-close" type="button" data-modal-close>&times;</button>
+        </div>
+        <div class="modal-body" id="log-detail">
+            <div class="form-grid">
+                <label>
+                    任务 ID
+                    <input id="log-detail-job" type="text" readonly />
+                </label>
+                <label>
+                    执行器地址
+                    <input id="log-detail-address" type="text" readonly />
+                </label>
+                <label>
+                    Handler
+                    <input id="log-detail-handler" type="text" readonly />
+                </label>
+                <label>
+                    触发时间
+                    <input id="log-detail-trigger" type="text" readonly />
+                </label>
+                <label>
+                    完成时间
+                    <input id="log-detail-handle" type="text" readonly />
+                </label>
+                <label>
+                    处理结果
+                    <input id="log-detail-status" type="text" readonly />
+                </label>
+            </div>
+            <pre class="log-content" id="log-detail-content">加载中...</pre>
+        </div>
+        <div class="modal-footer">
+            <button type="button" data-modal-close>关闭</button>
+        </div>
+    </div>
+</div>
+
+<div class="toast" id="toast"></div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+    const TOKEN_KEY = "xxl_admin_token";
+    const USERNAME_KEY = "xxl_admin_username";
+    const JOB_GROUPS_ENDPOINT = "{{ job_groups_endpoint }}";
+    const JOB_LOGS_ENDPOINT = "{{ job_logs_endpoint }}";
+
+    const token = localStorage.getItem(TOKEN_KEY);
+    if (!token) {
+        window.location.replace("/admin/");
+    }
+
+    const welcomeUser = document.getElementById("welcome-user");
+    const logoutBtn = document.getElementById("logout");
+    const logTableBody = document.getElementById("log-table-body");
+    const logTotalEl = document.getElementById("log-total");
+    const logFilterForm = document.getElementById("log-filter-form");
+    const logGroupSelect = document.getElementById("log-filter-group");
+    const toast = document.getElementById("toast");
+    const logModal = document.getElementById("log-modal");
+
+    welcomeUser.textContent = localStorage.getItem(USERNAME_KEY) || "未登录";
+    logTotalEl.dataset.total = '0';
+
+    const logFilters = {
+        job_group: "",
+        job_id: "",
+        log_status: "",
+        filter_time: "",
+        start: 0,
+        length: 10,
+    };
+
+    logoutBtn.addEventListener("click", () => {
+        localStorage.removeItem(TOKEN_KEY);
+        localStorage.removeItem(USERNAME_KEY);
+        window.location.replace("/admin/");
+    });
+
+    document.querySelectorAll('[data-modal-close]').forEach((el) => {
+        el.addEventListener('click', () => closeModal(el.closest('.modal')));
+    });
+
+    logModal.addEventListener('click', (event) => {
+        if (event.target.classList.contains('modal-backdrop')) {
+            closeModal(logModal);
+        }
+    });
+
+    document.getElementById('reload-logs').addEventListener('click', () => {
+        syncFilters();
+        loadLogs(true);
+    });
+
+    logFilterForm.addEventListener('submit', (event) => {
+        event.preventDefault();
+        syncFilters();
+        loadLogs(true);
+    });
+
+    document.getElementById('log-reset').addEventListener('click', () => {
+        document.getElementById('log-filter-job').value = '';
+        document.getElementById('log-filter-status').value = '';
+        document.getElementById('log-filter-start').value = '';
+        document.getElementById('log-filter-end').value = '';
+        syncFilters();
+        loadLogs(true);
+    });
+
+    document.getElementById('log-prev').addEventListener('click', () => {
+        if (logFilters.start >= logFilters.length) {
+            logFilters.start -= logFilters.length;
+            loadLogs();
+        }
+    });
+
+    document.getElementById('log-next').addEventListener('click', () => {
+        const total = Number(logTotalEl.dataset.total || 0);
+        if (logFilters.start + logFilters.length < total) {
+            logFilters.start += logFilters.length;
+            loadLogs();
+        }
+    });
+
+    document.getElementById('clear-logs').addEventListener('click', async () => {
+        if (!logFilters.job_group) {
+            showToast('请选择执行器后再清理', true);
+            return;
+        }
+        const days = prompt('请输入清理多少天前的日志，0 表示全部清理：', '30');
+        if (days === null) {
+            return;
+        }
+        const clearBeforeDays = Number(days);
+        if (Number.isNaN(clearBeforeDays) || clearBeforeDays < 0) {
+            showToast('请输入有效的天数', true);
+            return;
+        }
+        try {
+            await fetchJson(`${JOB_LOGS_ENDPOINT}/clear`, {
+                method: 'POST',
+                body: JSON.stringify({
+                    job_group: Number(logFilters.job_group),
+                    job_id: logFilters.job_id ? Number(logFilters.job_id) : undefined,
+                    clear_before_days: clearBeforeDays,
+                }),
+            });
+            showToast('日志清理任务已下发');
+            loadLogs(true);
+        } catch (error) {
+            showToast(error.message || '清理失败', true);
+        }
+    });
+
+    logTableBody.addEventListener('click', async (event) => {
+        const action = event.target.closest('[data-action]');
+        if (!action) {
+            return;
+        }
+        const id = Number(action.dataset.id);
+        if (action.dataset.action === 'view') {
+            await openLogDetail(id);
+        } else if (action.dataset.action === 'kill') {
+            if (!confirm('确定要强制终止该任务吗？')) {
+                return;
+            }
+            try {
+                await fetchJson(`${JOB_LOGS_ENDPOINT}/${id}/kill`, { method: 'POST' });
+                showToast('已标记为终止');
+                loadLogs();
+            } catch (error) {
+                showToast(error.message || '操作失败', true);
+            }
+        }
+    });
+
+    refreshGroupOptions().then(() => {
+        syncFilters();
+        if (logFilters.job_group) {
+            loadLogs(true);
+        }
+    });
+
+    function syncFilters() {
+        logFilters.job_group = logGroupSelect.value;
+        logFilters.job_id = document.getElementById('log-filter-job').value;
+        logFilters.log_status = document.getElementById('log-filter-status').value;
+        const start = formatInputDate(document.getElementById('log-filter-start').value);
+        const end = formatInputDate(document.getElementById('log-filter-end').value);
+        logFilters.filter_time = start && end ? `${start} - ${end}` : '';
+        logFilters.start = 0;
+    }
+
+    async function refreshGroupOptions() {
+        const previous = logGroupSelect.value;
+        try {
+            const params = new URLSearchParams({ start: '0', length: '200' });
+            const result = await fetchJson(`${JOB_GROUPS_ENDPOINT}?${params.toString()}`);
+            const groups = Array.isArray(result.data) ? result.data : [];
+            logGroupSelect.innerHTML = groups
+                .map((group) => `<option value="${group.id}">${group.id} - ${escapeHtml(group.appname)}</option>`)
+                .join('');
+            if (!groups.length) {
+                logGroupSelect.innerHTML = '<option value="">无执行器</option>';
+                logGroupSelect.value = '';
+                logGroupSelect.disabled = true;
+            } else if (previous && groups.some((group) => String(group.id) === previous)) {
+                logGroupSelect.value = previous;
+                logGroupSelect.disabled = false;
+            } else {
+                logGroupSelect.value = String(groups[0].id);
+                logGroupSelect.disabled = false;
+            }
+        } catch (error) {
+            logGroupSelect.innerHTML = '<option value="">无执行器</option>';
+            logGroupSelect.value = '';
+            logGroupSelect.disabled = true;
+            showToast(error.message || '加载执行器失败', true);
+        }
+    }
+
+    async function loadLogs(resetStart = false) {
+        if (!logFilters.job_group) {
+            logTableBody.innerHTML = '<tr><td colspan="7" class="muted">请选择执行器</td></tr>';
+            logTotalEl.textContent = '0';
+            logTotalEl.dataset.total = '0';
+            return;
+        }
+        if (resetStart) {
+            logFilters.start = 0;
+        }
+        const params = new URLSearchParams({
+            start: String(logFilters.start),
+            length: String(logFilters.length),
+            job_group: String(logFilters.job_group),
+        });
+        if (logFilters.job_id) {
+            params.set('job_id', logFilters.job_id);
+        }
+        if (logFilters.log_status) {
+            params.set('log_status', logFilters.log_status);
+        }
+        if (logFilters.filter_time) {
+            params.set('filter_time', logFilters.filter_time);
+        }
+        logTableBody.innerHTML = '<tr><td colspan="7" class="muted">加载中...</td></tr>';
+        try {
+            const result = await fetchJson(`${JOB_LOGS_ENDPOINT}?${params.toString()}`);
+            const logs = Array.isArray(result.data) ? result.data : [];
+            const total = result.records_total ?? logs.length;
+            logTotalEl.textContent = total;
+            logTotalEl.dataset.total = String(total);
+            renderLogTable(logs);
+        } catch (error) {
+            logTableBody.innerHTML = `<tr><td colspan="7" class="muted">${escapeHtml(error.message || '加载失败')}</td></tr>`;
+        }
+    }
+
+    function renderLogTable(logs) {
+        if (!logs.length) {
+            logTableBody.innerHTML = '<tr><td colspan="7" class="muted">暂无日志</td></tr>';
+            return;
+        }
+        logTableBody.innerHTML = logs
+            .map((log) => {
+                const status = log.handleCode === 200 ? 'success' : 'failed';
+                const statusText = log.handleCode === 200 ? '成功' : '失败';
+                return `
+                    <tr>
+                        <td>${log.id}</td>
+                        <td>${log.jobId}</td>
+                        <td>${escapeHtml(log.executorAddress || '--')}</td>
+                        <td>${escapeHtml(log.executorHandler || '--')}</td>
+                        <td>${displayDateTime(log.triggerTime)}</td>
+                        <td><span class="status-badge" data-status="${status}">${statusText}</span></td>
+                        <td>
+                            <div class="table-actions">
+                                <button type="button" data-action="view" data-id="${log.id}">查看</button>
+                                <button type="button" data-action="kill" data-id="${log.id}">终止</button>
+                            </div>
+                        </td>
+                    </tr>
+                `;
+            })
+            .join('');
+    }
+
+    async function openLogDetail(id) {
+        try {
+            const [detail, content] = await Promise.all([
+                fetchJson(`${JOB_LOGS_ENDPOINT}/${id}`),
+                fetchJson(`${JOB_LOGS_ENDPOINT}/${id}/cat?fromLineNum=1`),
+            ]);
+            document.getElementById('log-detail-job').value = detail.jobId;
+            document.getElementById('log-detail-address').value = detail.executorAddress || '--';
+            document.getElementById('log-detail-handler').value = detail.executorHandler || '--';
+            document.getElementById('log-detail-trigger').value = displayDateTime(detail.triggerTime);
+            document.getElementById('log-detail-handle').value = displayDateTime(detail.handleTime);
+            document.getElementById('log-detail-status').value = detail.handleCode === 200 ? '成功' : `失败(${detail.handleCode})`;
+            document.getElementById('log-detail-content').textContent = content.log_content || '暂无内容';
+            openModal(logModal);
+        } catch (error) {
+            showToast(error.message || '加载日志详情失败', true);
+        }
+    }
+
+    async function fetchJson(url, options = {}) {
+        const response = await fetch(url, {
+            ...options,
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${token}`,
+                ...(options.headers || {}),
+            },
+        });
+        if (!response.ok) {
+            const message = await response.json().catch(() => ({}));
+            throw new Error(message.message || response.statusText);
+        }
+        return response.json();
+    }
+
+    function formatInputDate(value) {
+        if (!value) {
+            return '';
+        }
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) {
+            return '';
+        }
+        return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')} ${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}:${String(date.getSeconds()).padStart(2, '0')}`;
+    }
+
+    function displayDateTime(value) {
+        if (!value) {
+            return '--';
+        }
+        try {
+            const date = new Date(value);
+            if (Number.isNaN(date.getTime())) {
+                return value;
+            }
+            return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')} ${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}:${String(date.getSeconds()).padStart(2, '0')}`;
+        } catch (error) {
+            return value;
+        }
+    }
+
+    function openModal(modal) {
+        modal.classList.remove('hidden');
+    }
+
+    function closeModal(modal) {
+        modal.classList.add('hidden');
+    }
+
+    function showToast(message, error = false) {
+        toast.textContent = message;
+        toast.classList.toggle('error', error);
+        toast.classList.add('show');
+        setTimeout(() => toast.classList.remove('show'), 3200);
+    }
+
+    function escapeHtml(value) {
+        if (value === null || value === undefined) {
+            return '';
+        }
+        return String(value).replace(/[&<>"']/g, (char) => {
+            switch (char) {
+                case '&':
+                    return '&amp;';
+                case '<':
+                    return '&lt;';
+                case '>':
+                    return '&gt;';
+                case '"':
+                    return '&quot;';
+                case "'":
+                    return '&#39;';
+                default:
+                    return char;
+            }
+        });
+    }
+</script>
+{% endblock %}

--- a/rust-admin/templates/layout.html
+++ b/rust-admin/templates/layout.html
@@ -18,9 +18,6 @@
             background: radial-gradient(circle at top, rgba(15, 118, 110, 0.25), transparent 55%),
                 radial-gradient(circle at bottom, rgba(59, 130, 246, 0.2), transparent 55%),
                 #0f172a;
-            display: flex;
-            justify-content: center;
-            align-items: center;
         }
 
         a {
@@ -29,8 +26,22 @@
 
         .app-shell {
             width: 100%;
+            min-height: 100vh;
             padding: 32px 16px;
             box-sizing: border-box;
+        }
+
+        .page-layout {
+            display: flex;
+            gap: 28px;
+            min-height: calc(100vh - 64px);
+        }
+
+        .page-main {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            gap: 24px;
         }
 
         .card {
@@ -39,7 +50,6 @@
             border: 1px solid rgba(148, 163, 184, 0.2);
             border-radius: 18px;
             box-shadow: 0 12px 45px rgba(15, 23, 42, 0.45);
-            margin: 0 auto;
         }
 
         .muted {
@@ -50,7 +60,8 @@
             cursor: pointer;
         }
 
-        input, button {
+        input,
+        button {
             font: inherit;
         }
 
@@ -63,8 +74,15 @@
     {% block head %}{% endblock %}
 </head>
 <body>
-<div class="app-shell">
-    {% block content %}{% endblock %}
+<div class="app-shell {% block shell_class %}{% endblock %}">
+    {% block shell %}
+    <div class="page-layout">
+        {% block sidebar %}{% endblock %}
+        <main class="page-main">
+            {% block content %}{% endblock %}
+        </main>
+    </div>
+    {% endblock %}
 </div>
 {% block scripts %}{% endblock %}
 </body>

--- a/rust-admin/templates/login.html
+++ b/rust-admin/templates/login.html
@@ -1,7 +1,25 @@
 {% extends "layout.html" %}
 
+{% block shell_class %}auth-shell{% endblock %}
+
 {% block head %}
 <style>
+    .auth-shell {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+    }
+
+    .auth-shell .page-layout {
+        width: 100%;
+        max-width: 520px;
+        justify-content: center;
+    }
+
+    .auth-shell .page-main {
+        max-width: 420px;
+    }
+
     .auth-card {
         max-width: 420px;
         padding: 48px 40px 40px;


### PR DESCRIPTION
## Summary
- add new Askama templates and routes for dashboard, task management, executor management, and log management screens
- rebuild the dashboard template to focus on the overview metrics with a sidebar that links to the new pages
- implement job, executor, and log pages with filters, CRUD modals, pagination, and API-driven actions that mirror the original XXL-Job console

## Testing
- cargo fmt
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68e37710abc083218435f284e2af7cd4