### PR TITLE
feat: add executor registry compatibility and refresh job admin UI

### DIFF
--- a/rust-admin/src/routes/openapi.rs
+++ b/rust-admin/src/routes/openapi.rs
@@ -1,0 +1,197 @@
+use axum::{extract::State, routing::post, Json, Router};
+use chrono::Utc;
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
+use serde::{Deserialize, Serialize};
+use tracing::{error, warn};
+
+use crate::entities::{job_log, job_registry};
+use crate::state::AppState;
+
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/registry", post(registry))
+        .route("/registryRemove", post(registry_remove))
+        .route("/callback", post(callback))
+}
+
+#[derive(Debug, Serialize)]
+struct ReturnT<T> {
+    code: i32,
+    msg: Option<String>,
+    content: Option<T>,
+}
+
+impl<T> ReturnT<T> {
+    fn success(content: Option<T>) -> Self {
+        Self {
+            code: 200,
+            msg: None,
+            content,
+        }
+    }
+
+    fn fail(message: impl Into<String>) -> Self {
+        Self {
+            code: 500,
+            msg: Some(message.into()),
+            content: None,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RegistryRequest {
+    registry_group: String,
+    registry_key: String,
+    registry_value: String,
+}
+
+async fn registry(
+    State(state): State<AppState>,
+    Json(payload): Json<RegistryRequest>,
+) -> Json<ReturnT<String>> {
+    match save_registry(&state, payload).await {
+        Ok(_) => Json(ReturnT::success(None)),
+        Err(err) => Json(ReturnT::fail(err)),
+    }
+}
+
+async fn save_registry(state: &AppState, payload: RegistryRequest) -> Result<(), String> {
+    let group = payload.registry_group.trim();
+    let key = payload.registry_key.trim();
+    let value = payload.registry_value.trim();
+
+    if group.is_empty() || key.is_empty() || value.is_empty() {
+        return Err("registryGroup/registryKey/registryValue 不能为空".into());
+    }
+
+    let now = Utc::now().naive_utc();
+    let existing = job_registry::Entity::find()
+        .filter(job_registry::Column::RegistryGroup.eq(group))
+        .filter(job_registry::Column::RegistryKey.eq(key))
+        .one(state.db())
+        .await
+        .map_err(|err| {
+            error!("查询执行器注册信息失败: {err}");
+            "保存执行器注册信息失败".to_string()
+        })?;
+
+    if let Some(mut model) = existing {
+        model.registry_value = value.to_string();
+        model.update_time = Some(now);
+        let active: job_registry::ActiveModel = model.into();
+        active.update(state.db()).await.map_err(|err| {
+            error!("更新执行器注册信息失败: {err}");
+            "保存执行器注册信息失败".to_string()
+        })?;
+    } else {
+        let active = job_registry::ActiveModel {
+            registry_group: Set(group.to_string()),
+            registry_key: Set(key.to_string()),
+            registry_value: Set(value.to_string()),
+            update_time: Set(Some(now)),
+            ..Default::default()
+        };
+        active.insert(state.db()).await.map_err(|err| {
+            error!("新增执行器注册信息失败: {err}");
+            "保存执行器注册信息失败".to_string()
+        })?;
+    }
+
+    Ok(())
+}
+
+async fn registry_remove(
+    State(state): State<AppState>,
+    Json(payload): Json<RegistryRequest>,
+) -> Json<ReturnT<String>> {
+    match remove_registry(&state, payload).await {
+        Ok(_) => Json(ReturnT::success(None)),
+        Err(err) => Json(ReturnT::fail(err)),
+    }
+}
+
+async fn remove_registry(state: &AppState, payload: RegistryRequest) -> Result<(), String> {
+    let group = payload.registry_group.trim();
+    let key = payload.registry_key.trim();
+    let value = payload.registry_value.trim();
+
+    if group.is_empty() || key.is_empty() || value.is_empty() {
+        return Err("registryGroup/registryKey/registryValue 不能为空".into());
+    }
+
+    job_registry::Entity::delete_many()
+        .filter(job_registry::Column::RegistryGroup.eq(group))
+        .filter(job_registry::Column::RegistryKey.eq(key))
+        .filter(job_registry::Column::RegistryValue.eq(value))
+        .exec(state.db())
+        .await
+        .map_err(|err| {
+            error!("删除执行器注册信息失败: {err}");
+            "删除执行器注册信息失败".to_string()
+        })?;
+
+    Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct HandleCallbackParam {
+    log_id: i64,
+    log_date_tim: i64,
+    handle_code: i32,
+    handle_msg: Option<String>,
+}
+
+async fn callback(
+    State(state): State<AppState>,
+    Json(params): Json<Vec<HandleCallbackParam>>,
+) -> Json<ReturnT<String>> {
+    for param in params {
+        if let Err(err) = process_callback(&state, param).await {
+            warn!("处理执行回调失败: {err}");
+        }
+    }
+
+    Json(ReturnT::success(None))
+}
+
+async fn process_callback(state: &AppState, param: HandleCallbackParam) -> Result<(), String> {
+    let mut model = job_log::Entity::find_by_id(param.log_id)
+        .one(state.db())
+        .await
+        .map_err(|err| {
+            error!("查询调度日志失败: {err}");
+            "查询调度日志失败".to_string()
+        })?
+        .ok_or_else(|| "log item not found.".to_string())?;
+
+    if model.handle_code > 0 {
+        return Err("log repeate callback.".into());
+    }
+
+    let mut combined_msg = model.handle_msg.unwrap_or_default();
+    if let Some(msg) = param.handle_msg {
+        if !combined_msg.is_empty() {
+            combined_msg.push('\n');
+        }
+        combined_msg.push_str(msg.trim());
+    }
+
+    model.handle_time = Some(Utc::now().naive_utc());
+    model.handle_code = param.handle_code;
+    model.handle_msg = if combined_msg.is_empty() {
+        None
+    } else {
+        Some(combined_msg)
+    };
+
+    let active: job_log::ActiveModel = model.into();
+    active.update(state.db()).await.map_err(|err| {
+        error!("更新调度日志失败: {err}");
+        "更新调度日志失败".to_string()
+    })?;
+
+    Ok(())
+}

--- a/rust-admin/templates/job-info.html
+++ b/rust-admin/templates/job-info.html
@@ -18,18 +18,26 @@
 {% block head %}
 <style>
     :root {
-        --border-color: rgba(148, 163, 184, 0.18);
-        --muted: rgba(226, 232, 240, 0.75);
-        --warning: #facc15;
-        --success: #22c55e;
+        --border-color: #e2e8f0;
+        --muted: #64748b;
+        --primary: #2563eb;
+        --primary-hover: #1d4ed8;
+        --surface: #ffffff;
+        --surface-muted: #f8fafc;
+        --warning: #f59e0b;
+        --success: #16a34a;
     }
 
     .sidebar {
-        width: 240px;
-        padding: 26px 22px;
+        width: 220px;
+        padding: 20px 18px;
         display: flex;
         flex-direction: column;
-        gap: 24px;
+        gap: 20px;
+        background: var(--surface);
+        border: 1px solid var(--border-color);
+        border-radius: 12px;
+        box-shadow: 0 8px 18px rgba(15, 23, 42, 0.05);
     }
 
     .sidebar-header {
@@ -40,61 +48,66 @@
 
     .sidebar-title {
         font-size: 18px;
-        font-weight: 700;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
+        font-weight: 600;
+        color: #0f172a;
+        letter-spacing: 0.02em;
     }
 
     .sidebar-subtitle {
         font-size: 13px;
+        color: var(--muted);
     }
 
     .sidebar-nav {
         display: flex;
         flex-direction: column;
-        gap: 10px;
+        gap: 8px;
     }
 
     .nav-link {
-        display: block;
-        width: 100%;
-        padding: 12px 14px;
-        border-radius: 12px;
-        border: 1px solid transparent;
-        background: rgba(148, 163, 184, 0.08);
-        color: inherit;
+        display: flex;
+        align-items: center;
+        padding: 10px 12px;
+        border-radius: 8px;
         text-decoration: none;
-        font-weight: 600;
-        transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+        color: #0f172a;
+        font-weight: 500;
+        transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
     }
 
     .nav-link:hover {
-        background: rgba(56, 189, 248, 0.18);
-        border-color: rgba(56, 189, 248, 0.45);
-        transform: translateX(2px);
+        background: var(--surface-muted);
+        color: var(--primary);
     }
 
     .nav-link.is-active {
-        background: linear-gradient(135deg, rgba(14, 165, 233, 0.22), rgba(37, 99, 235, 0.28));
-        border-color: rgba(59, 130, 246, 0.55);
-        box-shadow: 0 12px 24px rgba(37, 99, 235, 0.25);
+        background: var(--primary);
+        color: #ffffff;
+        box-shadow: 0 6px 16px rgba(37, 99, 235, 0.18);
     }
 
     .page-header {
         display: flex;
         justify-content: space-between;
         align-items: center;
-        padding: 24px 28px;
-        border-radius: 18px;
+        padding: 20px 24px;
+        border-radius: 12px;
         border: 1px solid var(--border-color);
-        background: rgba(15, 23, 42, 0.8);
-        margin-bottom: 24px;
+        background: var(--surface);
+        box-shadow: 0 4px 12px rgba(15, 23, 42, 0.05);
+        margin-bottom: 12px;
     }
 
     .page-header h1 {
         margin: 0;
-        font-size: 22px;
-        letter-spacing: 0.06em;
+        font-size: 20px;
+        color: #0f172a;
+    }
+
+    .page-header .muted {
+        margin-top: 4px;
+        color: var(--muted);
+        font-size: 13px;
     }
 
     .user-info {
@@ -102,17 +115,33 @@
         align-items: center;
         gap: 12px;
         font-size: 14px;
-        color: rgba(226, 232, 240, 0.8);
+        color: #0f172a;
+    }
+
+    .user-info button {
+        border: 1px solid var(--border-color);
+        background: #ffffff;
+        color: #334155;
+        padding: 6px 12px;
+        border-radius: 8px;
+        transition: border-color 0.2s ease, color 0.2s ease, background 0.2s ease;
+    }
+
+    .user-info button:hover {
+        border-color: var(--primary);
+        color: var(--primary);
+        background: var(--surface-muted);
     }
 
     .section-card {
-        padding: 24px 28px;
-        border-radius: 18px;
+        padding: 20px 24px;
+        border-radius: 12px;
         border: 1px solid var(--border-color);
-        background: rgba(15, 23, 42, 0.78);
+        background: var(--surface);
         display: flex;
         flex-direction: column;
-        gap: 20px;
+        gap: 18px;
+        box-shadow: 0 4px 12px rgba(15, 23, 42, 0.04);
     }
 
     .section-header {
@@ -122,38 +151,105 @@
         gap: 16px;
     }
 
+    .section-header h2 {
+        margin: 0;
+        font-size: 18px;
+        color: #0f172a;
+    }
+
+    .section-header .muted {
+        margin-top: 4px;
+        color: var(--muted);
+    }
+
     .section-actions {
         display: flex;
         gap: 12px;
     }
 
-    .section-actions button,
-    .filter-grid button {
-        background: rgba(148, 163, 184, 0.15);
-        border: 1px solid rgba(148, 163, 184, 0.3);
-        color: inherit;
-        padding: 8px 14px;
-        border-radius: 10px;
+    .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 6px;
+        padding: 8px 16px;
+        font-size: 14px;
+        border-radius: 8px;
+        border: 1px solid transparent;
+        background: #ffffff;
+        color: #1f2937;
+        transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .btn:hover {
+        background: var(--surface-muted);
+        border-color: var(--border-color);
+    }
+
+    .btn-primary {
+        background: var(--primary);
+        border-color: var(--primary);
+        color: #ffffff;
+        box-shadow: 0 6px 16px rgba(37, 99, 235, 0.2);
+    }
+
+    .btn-primary:hover {
+        background: var(--primary-hover);
+        border-color: var(--primary-hover);
+    }
+
+    .btn-secondary {
+        border-color: var(--border-color);
+    }
+
+    .btn-secondary:hover {
+        border-color: var(--primary);
+        color: var(--primary);
+    }
+
+    .btn-ghost {
+        background: transparent;
+        border-color: transparent;
+        color: #1f2937;
+        padding: 4px 10px;
         font-size: 13px;
+    }
+
+    .btn-ghost:hover {
+        background: var(--surface-muted);
+        color: var(--primary);
+    }
+
+    .btn-danger {
+        background: #fee2e2;
+        border-color: #fecaca;
+        color: #b91c1c;
+    }
+
+    .btn-danger:hover {
+        background: #fecaca;
+        border-color: #fca5a5;
+        color: #991b1b;
     }
 
     .filter-grid {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-        gap: 12px 18px;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 16px 20px;
         align-items: end;
     }
 
     .filter-grid label {
         display: flex;
         flex-direction: column;
-        gap: 6px;
+        gap: 8px;
         font-size: 13px;
+        color: #475569;
     }
 
     .form-actions {
         display: flex;
-        gap: 10px;
+        gap: 12px;
     }
 
     .filter-grid input,
@@ -161,12 +257,23 @@
     .modal-body input,
     .modal-body textarea,
     .modal-body select {
-        padding: 8px 10px;
+        padding: 10px 12px;
         border-radius: 8px;
-        border: 1px solid rgba(148, 163, 184, 0.35);
-        background: rgba(15, 23, 42, 0.65);
-        color: inherit;
+        border: 1px solid var(--border-color);
+        background: #ffffff;
+        color: #0f172a;
         font: inherit;
+        transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .filter-grid input:focus,
+    .filter-grid select:focus,
+    .modal-body input:focus,
+    .modal-body textarea:focus,
+    .modal-body select:focus {
+        border-color: var(--primary);
+        box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+        outline: none;
     }
 
     table {
@@ -174,12 +281,26 @@
         border-collapse: collapse;
     }
 
-    th,
+    th {
+        text-align: left;
+        padding: 12px 0;
+        border-bottom: 1px solid var(--border-color);
+        font-weight: 600;
+        font-size: 13px;
+        color: #475569;
+    }
+
     td {
         text-align: left;
-        padding: 10px 0;
-        border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+        padding: 12px 0;
+        border-bottom: 1px solid #f1f5f9;
         vertical-align: middle;
+        color: #0f172a;
+        font-size: 14px;
+    }
+
+    tbody tr:hover {
+        background: var(--surface-muted);
     }
 
     .status-badge {
@@ -189,38 +310,31 @@
         padding: 2px 10px;
         border-radius: 999px;
         font-size: 12px;
-        background: rgba(148, 163, 184, 0.15);
+        background: #e2e8f0;
+        color: #475569;
     }
 
     .status-badge[data-status="running"] {
-        background: rgba(250, 204, 21, 0.2);
-        color: var(--warning);
+        background: #dcfce7;
+        color: var(--success);
     }
 
     .status-badge[data-status="stopped"] {
-        background: rgba(148, 163, 184, 0.12);
+        background: #fee2e2;
+        color: #b91c1c;
     }
 
     .table-actions {
         display: inline-flex;
-        gap: 8px;
+        gap: 6px;
         flex-wrap: wrap;
-    }
-
-    .table-actions button {
-        background: transparent;
-        border: 1px solid rgba(148, 163, 184, 0.32);
-        color: inherit;
-        padding: 4px 10px;
-        border-radius: 8px;
-        font-size: 12px;
     }
 
     .table-footer {
         display: flex;
         justify-content: space-between;
         align-items: center;
-        font-size: 12px;
+        font-size: 13px;
         color: var(--muted);
     }
 
@@ -229,8 +343,12 @@
         gap: 8px;
     }
 
+    .pager button {
+        min-width: 88px;
+    }
+
     .pager button[disabled] {
-        opacity: 0.4;
+        opacity: 0.5;
         cursor: not-allowed;
     }
 
@@ -250,8 +368,8 @@
     .modal-backdrop {
         position: absolute;
         inset: 0;
-        background: rgba(15, 23, 42, 0.65);
-        backdrop-filter: blur(6px);
+        background: rgba(15, 23, 42, 0.45);
+        backdrop-filter: blur(2px);
     }
 
     .modal-content {
@@ -259,10 +377,14 @@
         width: min(900px, 94vw);
         max-height: 90vh;
         overflow-y: auto;
-        padding: 28px 30px;
+        padding: 24px 28px;
         display: flex;
         flex-direction: column;
         gap: 20px;
+        background: var(--surface);
+        border: 1px solid var(--border-color);
+        border-radius: 12px;
+        box-shadow: 0 18px 40px rgba(15, 23, 42, 0.25);
     }
 
     .modal-header {
@@ -273,15 +395,22 @@
 
     .modal-header h3 {
         margin: 0;
+        font-size: 18px;
+        color: #0f172a;
     }
 
     .modal-close {
         background: transparent;
         border: none;
-        color: inherit;
+        color: #94a3b8;
         font-size: 24px;
         line-height: 1;
         cursor: pointer;
+        transition: color 0.2s ease;
+    }
+
+    .modal-close:hover {
+        color: #334155;
     }
 
     .modal-body {
@@ -304,6 +433,7 @@
         display: flex;
         flex-direction: column;
         gap: 8px;
+        color: #475569;
     }
 
     .modal-footer {
@@ -312,24 +442,15 @@
         gap: 12px;
     }
 
-    .modal-footer button {
-        padding: 10px 18px;
-        border-radius: 10px;
-        border: 1px solid rgba(148, 163, 184, 0.4);
-        background: rgba(148, 163, 184, 0.18);
-        color: inherit;
-        font-size: 14px;
-    }
-
     .toast {
         position: fixed;
         top: 24px;
         right: 24px;
         padding: 12px 16px;
-        border-radius: 12px;
-        background: rgba(56, 189, 248, 0.85);
-        color: white;
-        box-shadow: 0 10px 30px rgba(56, 189, 248, 0.35);
+        border-radius: 10px;
+        background: var(--primary);
+        color: #ffffff;
+        box-shadow: 0 10px 30px rgba(37, 99, 235, 0.25);
         opacity: 0;
         pointer-events: none;
         transition: opacity 0.3s ease;
@@ -337,8 +458,8 @@
     }
 
     .toast.error {
-        background: rgba(239, 68, 68, 0.85);
-        box-shadow: 0 10px 30px rgba(239, 68, 68, 0.35);
+        background: #ef4444;
+        box-shadow: 0 10px 30px rgba(239, 68, 68, 0.25);
     }
 
     .toast.show {
@@ -353,6 +474,9 @@
 
         .sidebar {
             width: 100%;
+            flex-direction: row;
+            align-items: stretch;
+            gap: 16px;
         }
 
         .sidebar-nav {
@@ -361,7 +485,8 @@
         }
 
         .nav-link {
-            flex: 1 1 160px;
+            flex: 1 1 140px;
+            justify-content: center;
         }
     }
 </style>
@@ -374,8 +499,8 @@
         <div class="muted">按执行器维护调度任务，支持新增、编辑、启停与手动触发</div>
     </div>
     <div class="user-info">
-        <span id="welcome-user">--</span>
-        <button id="logout" type="button">退出登录</button>
+        <span id="welcome-user" class="muted">--</span>
+        <button id="logout" type="button" class="btn btn-secondary">退出登录</button>
     </div>
 </div>
 
@@ -386,8 +511,8 @@
             <div class="muted">查看任务状态并执行操作</div>
         </div>
         <div class="section-actions">
-            <button id="open-job-modal" type="button">新增任务</button>
-            <button id="reload-jobs" type="button">刷新</button>
+            <button id="open-job-modal" type="button" class="btn btn-primary">新增任务</button>
+            <button id="reload-jobs" type="button" class="btn btn-secondary">刷新</button>
         </div>
     </div>
     <form id="job-filter-form" class="filter-grid">
@@ -416,8 +541,8 @@
             <input id="job-filter-author" type="text" placeholder="维护人" />
         </label>
         <div class="form-actions">
-            <button type="submit">查询</button>
-            <button type="button" id="job-reset">重置</button>
+            <button type="submit" class="btn btn-primary">查询</button>
+            <button type="button" id="job-reset" class="btn btn-secondary">重置</button>
         </div>
     </form>
     <table>
@@ -442,8 +567,8 @@
     <div class="table-footer">
         <div>共 <span id="job-total">0</span> 条记录</div>
         <div class="pager">
-            <button type="button" id="job-prev">上一页</button>
-            <button type="button" id="job-next">下一页</button>
+            <button type="button" id="job-prev" class="btn btn-secondary">上一页</button>
+            <button type="button" id="job-next" class="btn btn-secondary">下一页</button>
         </div>
     </div>
 </section>
@@ -555,13 +680,13 @@
                     </label>
                 </div>
                 <div class="trigger-preview">
-                    <button type="button" id="preview-trigger">预览最近执行时间</button>
+                    <button type="button" id="preview-trigger" class="btn btn-secondary">预览最近执行时间</button>
                     <div id="trigger-preview-list" class="muted" style="font-size: 13px;">--</div>
                 </div>
             </div>
             <div class="modal-footer">
-                <button type="button" data-modal-close>取消</button>
-                <button type="submit">保存</button>
+                <button type="button" data-modal-close class="btn btn-secondary">取消</button>
+                <button type="submit" class="btn btn-primary">保存</button>
             </div>
         </form>
     </div>
@@ -586,8 +711,8 @@
                 </label>
             </div>
             <div class="modal-footer">
-                <button type="button" data-modal-close>取消</button>
-                <button type="submit">立即触发</button>
+                <button type="button" data-modal-close class="btn btn-secondary">取消</button>
+                <button type="submit" class="btn btn-primary">立即触发</button>
             </div>
         </form>
     </div>
@@ -966,10 +1091,10 @@
                         <td>${displayTimestamp(job.triggerNextTime)}</td>
                         <td>
                             <div class="table-actions">
-                                <button type="button" data-action="edit" data-id="${job.id}">编辑</button>
-                                <button type="button" data-action="${status === 'running' ? 'stop' : 'start'}" data-id="${job.id}">${status === 'running' ? '停止' : '启动'}</button>
-                                <button type="button" data-action="trigger" data-id="${job.id}">触发</button>
-                                <button type="button" data-action="delete" data-id="${job.id}">删除</button>
+                                <button type="button" class="btn btn-ghost" data-action="edit" data-id="${job.id}">编辑</button>
+                                <button type="button" class="btn btn-secondary" data-action="${status === 'running' ? 'stop' : 'start'}" data-id="${job.id}">${status === 'running' ? '停止' : '启动'}</button>
+                                <button type="button" class="btn btn-secondary" data-action="trigger" data-id="${job.id}">触发</button>
+                                <button type="button" class="btn btn-danger" data-action="delete" data-id="${job.id}">删除</button>
                             </div>
                         </td>
                     </tr>

--- a/rust-admin/templates/layout.html
+++ b/rust-admin/templates/layout.html
@@ -6,34 +6,33 @@
     <title>{{ app_name }}</title>
     <style>
         :root {
-            color-scheme: light dark;
+            color-scheme: light;
             font-family: "Inter", "PingFang SC", "Helvetica Neue", Arial, sans-serif;
-            background-color: #0f172a;
-            color: #f1f5f9;
+            background-color: #f4f6fb;
+            color: #0f172a;
         }
 
         body {
             margin: 0;
             min-height: 100vh;
-            background: radial-gradient(circle at top, rgba(15, 118, 110, 0.25), transparent 55%),
-                radial-gradient(circle at bottom, rgba(59, 130, 246, 0.2), transparent 55%),
-                #0f172a;
+            background-color: #f4f6fb;
+            color: #0f172a;
         }
 
         a {
-            color: #38bdf8;
+            color: #2563eb;
         }
 
         .app-shell {
             width: 100%;
             min-height: 100vh;
-            padding: 32px 16px;
+            padding: 32px 20px;
             box-sizing: border-box;
         }
 
         .page-layout {
             display: flex;
-            gap: 28px;
+            gap: 24px;
             min-height: calc(100vh - 64px);
         }
 
@@ -45,15 +44,14 @@
         }
 
         .card {
-            background: rgba(15, 23, 42, 0.85);
-            backdrop-filter: blur(18px);
-            border: 1px solid rgba(148, 163, 184, 0.2);
-            border-radius: 18px;
-            box-shadow: 0 12px 45px rgba(15, 23, 42, 0.45);
+            background: #ffffff;
+            border: 1px solid #e2e8f0;
+            border-radius: 12px;
+            box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
         }
 
         .muted {
-            color: rgba(226, 232, 240, 0.75);
+            color: #64748b;
         }
 
         button {
@@ -61,13 +59,15 @@
         }
 
         input,
-        button {
+        button,
+        select,
+        textarea {
             font: inherit;
         }
 
         @media (min-width: 1024px) {
             .app-shell {
-                padding: 48px;
+                padding: 48px 56px;
             }
         }
     </style>


### PR DESCRIPTION
## Summary
- add an open API router that exposes registry, registryRemove, and callback endpoints for executor compatibility and the legacy /xxl-job-admin path
- refresh the layout and job management page styling for a cleaner light-theme experience and consistent button styles
- adjust job action buttons and modals to use the new design tokens and controls

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e394bbf7008321851e6cd3d0008891